### PR TITLE
Disable progress for dexplode-partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix bug in schema handling (compressor settings ignored)
 - Move making ICF field partition directories into per-partition processing.
   Remove progress on the init mkdirs step.
+- Turn off progress monitor on dexplode-partition
 
 # 0.0.4 2024-04-08
 

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -207,7 +207,7 @@ def dexplode_partition(icf_path, partition, verbose):
     from 0 (inclusive) to the number of paritions returned by dexplode_init (exclusive).
     """
     setup_logging(verbose)
-    vcf.explode_partition(icf_path, partition, show_progress=True)
+    vcf.explode_partition(icf_path, partition, show_progress=False)
 
 
 @click.command


### PR DESCRIPTION
Not helpful when run non-interactively, so turn it off