### PR TITLE
Add CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,86 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  release:
+    types: [published]
+
+jobs:
+  packaging:
+    if: github.repository_owner == 'sgkit-dev'
+    name: Packaging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine validate-pyproject[all]
+      - name: Check and install package
+        run: |
+          validate-pyproject pyproject.toml
+          python -m build
+          python -m twine check --strict dist/*
+          python -m pip install dist/*.whl
+      - name: Check vcf2zarr CLI
+        run: |
+          vcf2zarr --help
+          python -m bio2zarr vcf2zarr --help
+      - name: Check vcfpartition CLI
+        run: |
+          vcfpartition --help
+          python -m bio2zarr vcfpartition --help
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    if: github.repository_owner == 'sgkit-dev' && github.event_name == 'release'
+    needs:
+      - packaging
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bio2zarr
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - uses: pypa/gh-action-pypi-publish@release/v1
+
+
+  publish-to-testpypi:
+    if: github.repository_owner == 'sgkit-dev' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    needs:
+      - packaging
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/bio2zarr
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, test]
+    branches:
+      - main
 
 jobs:
   pre-commit:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,8 @@ name: Build Docs
 on:
   pull_request:
   push:
-    branches: [main, test]
+    branches:
+      - main
     tags:
       - '*'
 


### PR DESCRIPTION
Re: https://github.com/sgkit-dev/bio2zarr/issues/154

This is based on sgkit's wheels workflow and https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows, the differences are:
 * the workflow is designed for Trusted Publishing: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing
 * I have moved the packaging + package testing from CI to CD workflow, but we could consider having it in both?
 * the testpypi pushing happens on tag, but maybe it should happen on `test` branch? I'm not entirely sure what is the purpose of the `test` branch in this repo, but that's something to consider.

For this to work, @jeromekelleher you will need to configure Trusted Publishing as documented in the link above, copy pasting here:
1. Go to https://pypi.org/manage/account/publishing/.
   Fill in the name you wish to publish your new [PyPI project](https://packaging.python.org/en/latest/glossary/#term-Project) under (the name value in your setup.cfg or pyproject.toml), the GitHub repository owner’s name (org or user), and repository name, and the name of the release workflow file under the .github/ folder, see [Creating a workflow definition](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#workflow-definition). Finally, add the name of the GitHub Environment (pypi) we’re going set up under your repository. Register the trusted publisher.

2. Now, go to https://test.pypi.org/manage/account/publishing/ and repeat the second step, but this time, enter testpypi as the name of the GitHub Environment.

3. Your “pending” publishers are now ready for their first use and will create your projects automatically once you use them for the first time.