### PR TITLE
Bump upload artefact to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
           vcfpartition --help
           python -m bio2zarr vcfpartition --help
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -56,7 +56,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -77,7 +77,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
Upload/download will stop working in November, so worth bumping them. Node warnings must be coming from other actions, so no point in worrying about them.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Closes #181