### PR TITLE
Add multiple-file support to vcfpartition

### DIFF
--- a/docs/vcfpartition/overview.md
+++ b/docs/vcfpartition/overview.md
@@ -20,7 +20,7 @@ cp ../../tests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz* ./
 ## Overview
 
 The {ref}`cmd-vcfpartition` utility outputs a set of region strings
-that partition an indexed VCF/BCF into either an approximate number of 
+that partition indexed VCF/BCF files into either an approximate number of 
 parts, or into parts of approximately a given size. This is useful 
 for parallel processing of large VCF files.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -751,7 +751,7 @@ class TestVcfEndToEnd:
 
 class TestVcfPartition:
     path = "tests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz"
-    paths = [path, "tests/data/vcf/1kg_2020_chrM.vcf.gz"]
+    paths = (path, "tests/data/vcf/1kg_2020_chrM.vcf.gz")
 
     def test_num_parts(self):
         runner = ct.CliRunner(mix_stderr=False)
@@ -810,7 +810,7 @@ class TestVcfPartition:
         assert list(result.stdout.splitlines()) == [
             "20:60001-540672\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
             "20:540674-\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
-            "chrM:26-\ttests/data/vcf/1kg_2020_chrM.vcf.gz"
+            "chrM:26-\ttests/data/vcf/1kg_2020_chrM.vcf.gz",
         ]
 
     def test_part_size_multiple_vcfs(self):
@@ -829,7 +829,7 @@ class TestVcfPartition:
             "20:688129-802816\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
             "20:802817-933888\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
             "20:933890-\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
-            "chrM:26-\ttests/data/vcf/1kg_2020_chrM.vcf.gz"
+            "chrM:26-\ttests/data/vcf/1kg_2020_chrM.vcf.gz",
         ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -751,6 +751,7 @@ class TestVcfEndToEnd:
 
 class TestVcfPartition:
     path = "tests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz"
+    paths = [path, "tests/data/vcf/1kg_2020_chrM.vcf.gz"]
 
     def test_num_parts(self):
         runner = ct.CliRunner(mix_stderr=False)
@@ -798,6 +799,38 @@ class TestVcfPartition:
         assert result.exit_code != 0
         assert result.stdout == ""
         assert len(result.stderr) > 0
+
+    def test_num_parts_multiple_vcfs(self):
+        runner = ct.CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            cli.vcfpartition, [*self.paths, "-n", "5"], catch_exceptions=False
+        )
+        assert result.stderr == ""
+        assert result.exit_code == 0
+        assert list(result.stdout.splitlines()) == [
+            "20:60001-540672\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "20:540674-\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "chrM:26-\ttests/data/vcf/1kg_2020_chrM.vcf.gz"
+        ]
+
+    def test_part_size_multiple_vcfs(self):
+        runner = ct.CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            cli.vcfpartition, [*self.paths, "-s", "512K"], catch_exceptions=False
+        )
+        assert result.stderr == ""
+        assert result.exit_code == 0
+        assert list(result.stdout.splitlines()) == [
+            "20:60001-212992\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "20:213070-327680\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "20:327695-442368\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "20:442381-557056\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "20:557078-688128\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "20:688129-802816\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "20:802817-933888\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "20:933890-\ttests/data/vcf/NA12878.prod.chr20snippet.g.vcf.gz",
+            "chrM:26-\ttests/data/vcf/1kg_2020_chrM.vcf.gz"
+        ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

This pull request adds support for multiple VCF/BCF files to the vcfpartition command and closes #212.

When the user specifies multiple VCF/BCF files, vcfpartition interprets the number of partitions argument as the total number of partitions among all the files. The partitions are distributed evenly among the files.

Let me know if we should add a section to the vcfpartition that describes how to partition multiple files.

### Testing

I added some unit tests to test the changes to the vcfpartition CLI.

I tried to check the documentation changes manually by building the documentation (running `make -C docs` from the project directory), but I encountered this error:

```
rm -fR sample.vcz
asciinema-automation cast_scripts/vcf2zarr_convert.sh _static/vcf2zarr_convert.cast
make: asciinema-automation: No such file or directory
make: *** [_static/vcf2zarr_convert.cast] Error 1
```

I didn't spend much time trying to resolve this, but if you know the fix, that would help!