### PR TITLE
Refactor variable names for consistency

### DIFF
--- a/bio2zarr/vcf2zarr/icf.py
+++ b/bio2zarr/vcf2zarr/icf.py
@@ -853,11 +853,11 @@ class IntermediateColumnarFormat(collections.abc.Mapping):
 
     def summary_table(self):
         data = []
-        for name, col in self.fields.items():
-            summary = col.vcf_field.summary
+        for name, icf_field in self.fields.items():
+            summary = icf_field.vcf_field.summary
             d = {
                 "name": name,
-                "type": col.vcf_field.vcf_type,
+                "type": icf_field.vcf_field.vcf_type,
                 "chunks": summary.num_chunks,
                 "size": core.display_size(summary.uncompressed_size),
                 "compressed": core.display_size(summary.compressed_size),
@@ -1009,8 +1009,8 @@ class IntermediateColumnarFormatWriter:
         self.path.mkdir()
         self.wip_path.mkdir()
         for field in self.metadata.fields:
-            col_path = get_vcf_field_path(self.path, field)
-            col_path.mkdir(parents=True)
+            field_path = get_vcf_field_path(self.path, field)
+            field_path.mkdir(parents=True)
 
     def load_partition_summaries(self):
         summaries = []

--- a/tests/test_icf.py
+++ b/tests/test_icf.py
@@ -46,8 +46,8 @@ class TestSmallExample:
 
     def test_summary_table(self, icf):
         data = icf.summary_table()
-        cols = [d["name"] for d in data]
-        assert tuple(sorted(cols)) == self.fields
+        fields = [d["name"] for d in data]
+        assert tuple(sorted(fields)) == self.fields
 
     def test_inspect(self, icf):
         assert icf.summary_table() == vcf2zarr.inspect(icf.path)
@@ -111,10 +111,10 @@ class TestIcfWriterExample:
         assert icf_path.exists()
         wip_path = icf_path / "wip"
         assert wip_path.exists()
-        for column in self.fields:
-            col_path = icf_path / column
-            assert col_path.exists()
-            assert col_path.is_dir()
+        for field_name in self.fields:
+            field_path = icf_path / field_name
+            assert field_path.exists()
+            assert field_path.is_dir()
 
     def test_finalise_paths(self, tmp_path):
         icf_path = tmp_path / "x.icf"
@@ -427,8 +427,8 @@ class TestSlicing:
         )
 
     def test_pos_values(self, icf):
-        col = icf["POS"]
-        pos = np.array([v[0] for v in col.values])
+        field = icf["POS"]
+        pos = np.array([v[0] for v in field.values])
         # Check the actual values here to make sure other tests make sense
         actual = np.hstack([1 + np.arange(933) for _ in range(5)])
         nt.assert_array_equal(pos, actual)
@@ -465,9 +465,9 @@ class TestSlicing:
         ],
     )
     def test_slice(self, icf, start, stop):
-        col = icf["POS"]
-        pos = np.array(col.values)
-        pos_slice = np.array(list(col.iter_values(start, stop)))
+        field = icf["POS"]
+        pos = np.array(field.values)
+        pos_slice = np.array(list(field.iter_values(start, stop)))
         nt.assert_array_equal(pos[start:stop], pos_slice)
 
 

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -238,9 +238,9 @@ class TestSmallExample:
         vcf2zarr.convert([path], out)
         ds2 = sg.load_dataset(out)
         assert len(ds2["sample_id"]) == 0
-        for col in ds:
-            if col != "sample_id" and not col.startswith("call_"):
-                xt.assert_equal(ds[col], ds2[col])
+        for field_name in ds:
+            if field_name != "sample_id" and not field_name.startswith("call_"):
+                xt.assert_equal(ds[field_name], ds2[field_name])
 
     @pytest.mark.parametrize(
         ("variants_chunk_size", "samples_chunk_size", "y_chunks", "x_chunks"),

--- a/tests/test_vcz.py
+++ b/tests/test_vcz.py
@@ -178,17 +178,17 @@ class TestSchemaEncode:
         zarr_path = tmp_path / "zarr"
         icf = vcf2zarr.IntermediateColumnarFormat(icf_path)
         schema = vcf2zarr.VcfZarrSchema.generate(icf)
-        for var in schema.fields:
-            var.compressor["cname"] = cname
-            var.compressor["clevel"] = clevel
-            var.compressor["shuffle"] = shuffle
+        for array_spec in schema.fields:
+            array_spec.compressor["cname"] = cname
+            array_spec.compressor["clevel"] = clevel
+            array_spec.compressor["shuffle"] = shuffle
         schema_path = tmp_path / "schema"
         with open(schema_path, "w") as f:
             f.write(schema.asjson())
         vcf2zarr.encode(icf_path, zarr_path, schema_path=schema_path)
         root = zarr.open(zarr_path)
-        for var in schema.fields:
-            a = root[var.name]
+        for array_spec in schema.fields:
+            a = root[array_spec.name]
             assert a.compressor.cname == cname
             assert a.compressor.clevel == clevel
             assert a.compressor.shuffle == shuffle


### PR DESCRIPTION
### Description

This pull request renames variables throughout the project for consistency and closes #165.

In general, the goal is to use the term "array" when referring to Zarr arrays and the term "field" in most other situations, as opposed to "column" or "variable".

In this pull request, I typically use the type of the Python object to determine an appropriate name. For example, I would name a Python variable that is a `ZarrArraySpec` instance `array_spec`. I determined the type of the objects by running the unit tests with the debugger. There are other locations in the code that refer to `ZarrArraySpec` instances as "fields" though—if desired, I can rename these as well for more consistency.

I also searched for uses of "var". In most cases, it seemed like "var" was used to mean "variant" and not "variable", so I left most of these alone.

### Methods

I used regular expression searches to find the instances of the different terminology. For example, `col[^umn]` to find variables named something like `col`.

I used PyCharm's refactoring features to rename the Python variables.

### Testing

I did not perform any testing of the changes. I am assuming that the unit tests will detect any issues.