### PR TITLE
Add descriptions for the fixed fields

### DIFF
--- a/bio2zarr/vcf2zarr/vcz.py
+++ b/bio2zarr/vcf2zarr/vcz.py
@@ -32,6 +32,16 @@ def inspect(path):
 
 DEFAULT_ZARR_COMPRESSOR = numcodecs.Blosc(cname="zstd", clevel=7)
 
+_fixed_field_descriptions = {
+    "variant_contig": "An identifier from the reference genome or an angle-bracketed ID"
+    " string pointing to a contig in the assembly file",
+    "variant_position": "The reference position",
+    "variant_id": "List of unique identifiers where applicable",
+    "variant_allele": "List of the reference and alternate alleles",
+    "variant_quality": "Phred-scaled quality score",
+    "variant_filter": "Filter status of the variant",
+}
+
 
 @dataclasses.dataclass
 class ZarrArraySpec:
@@ -46,6 +56,9 @@ class ZarrArraySpec:
     filters: list
 
     def __post_init__(self):
+        if self.name in _fixed_field_descriptions:
+            self.description = self.description or _fixed_field_descriptions[self.name]
+
         # Ensure these are tuples for ease of comparison and consistency
         self.shape = tuple(self.shape)
         self.chunks = tuple(self.chunks)

--- a/tests/test_vcz.py
+++ b/tests/test_vcz.py
@@ -295,7 +295,8 @@ class TestDefaultSchema:
             "shape": (9,),
             "chunks": (10000,),
             "dimensions": ("variants",),
-            "description": "An identifier from the reference genome",
+            "description": "An identifier from the reference genome or an "
+            "angle-bracketed ID string pointing to a contig in the assembly file",
             "vcf_field": None,
             "compressor": {
                 "id": "blosc",

--- a/tests/test_vcz.py
+++ b/tests/test_vcz.py
@@ -295,7 +295,7 @@ class TestDefaultSchema:
             "shape": (9,),
             "chunks": (10000,),
             "dimensions": ("variants",),
-            "description": "",
+            "description": "An identifier from the reference genome",
             "vcf_field": None,
             "compressor": {
                 "id": "blosc",


### PR DESCRIPTION
### Description

This pull request adds descriptions for the fixed fields in VCF Zarr. The fixed VCF Zarr fields are listed [here](https://github.com/sgkit-dev/vcf-zarr-spec/blob/main/vcf_zarr_spec.md#fixed-fields), and descriptions for their corresponding VCF fields are found in the [VCF specification](https://samtools.github.io/hts-specs/). I consulted the specification for VCFv4.3 to come up with the short descriptions.

This pull request closes #124.

### Approach

I add a dictionary relating the names of the fixed fields to their descriptions. `ZarrArraySpec` uses the dictionary during post-initialization to set the description field. The description is then set as an attribute of the Zarr array by the `VcfZarrWriter` in `init_array`, which is called by `init`.

### Testing

So far, I have only updated a unit test in `test_vcz.py` that fails with the new changes.