### PR TITLE
Change local alleles default to false

### DIFF
--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -152,7 +152,7 @@ max_memory = click.option(
 local_alleles = click.option(
     "--local-alleles/--no-local-alleles",
     show_default=True,
-    default=True,
+    default=False,
     help="Use local allele fields to reduce the storage requirements of the output.",
 )
 

--- a/bio2zarr/vcf2zarr/icf.py
+++ b/bio2zarr/vcf2zarr/icf.py
@@ -1155,7 +1155,7 @@ class IntermediateColumnarFormatWriter:
         if compressor is None:
             compressor = ICF_DEFAULT_COMPRESSOR
         if local_alleles is None:
-            local_alleles = True
+            local_alleles = False
         vcfs = [pathlib.Path(vcf) for vcf in vcfs]
         target_num_partitions = max(target_num_partitions, len(vcfs))
 

--- a/bio2zarr/vcf2zarr/verification.py
+++ b/bio2zarr/vcf2zarr/verification.py
@@ -170,10 +170,6 @@ def verify(vcf_path, zarr_path, show_progress=False):
     for colname in root.keys():
         if colname.startswith("call") and not colname.startswith("call_genotype"):
             vcf_name = colname.split("_", 1)[1]
-            if vcf_name == "LAA" and vcf_name not in format_headers:
-                continue  # LAA could have been computed during the explode step.
-            if vcf_name == "LPL" and vcf_name not in format_headers:
-                continue  # LPL could have been computed during the explode step.
             vcf_type = format_headers[vcf_name]["Type"]
             vcf_number = format_headers[vcf_name]["Number"]
             format_fields[vcf_name] = vcf_type, vcf_number, iter(root[colname])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ DEFAULT_EXPLODE_ARGS = dict(
     compressor=None,
     worker_processes=1,
     show_progress=True,
-    local_alleles=True,
+    local_alleles=False,
 )
 
 DEFAULT_DEXPLODE_PARTITION_ARGS = dict()
@@ -24,7 +24,7 @@ DEFAULT_DEXPLODE_INIT_ARGS = dict(
     column_chunk_size=64,
     compressor=None,
     show_progress=True,
-    local_alleles=True,
+    local_alleles=False,
 )
 
 DEFAULT_ENCODE_ARGS = dict(
@@ -54,7 +54,7 @@ DEFAULT_CONVERT_ARGS = dict(
     samples_chunk_size=None,
     show_progress=True,
     worker_processes=1,
-    local_alleles=True,
+    local_alleles=False,
 )
 
 DEFAULT_PLINK_CONVERT_ARGS = dict(

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -537,7 +537,7 @@ class Test1000G2020Example:
     @pytest.fixture(scope="class")
     def ds(self, tmp_path_factory):
         out = tmp_path_factory.mktemp("data") / "example.vcf.zarr"
-        vcf2zarr.convert([self.data_path], out, worker_processes=0)
+        vcf2zarr.convert([self.data_path], out, worker_processes=0, local_alleles=True)
         return sg.load_dataset(out)
 
     def test_position(self, ds):


### PR DESCRIPTION
### Overview

`vcf2zarr explode` has a CLI option to create local-allele fields during the explode process. Currently, the CLI option's default value is true. This pull request changes the default value to false.

The default value should be false because the local alleles option is in an experimental stage of development. The current implementation does not save as much storage as hoped for and does not yet prevent the larger, global (non-local-allele) fields from being converted as well. See #277.

### Testing

There are unit tests that test the default value of the local alleles option. I update those unit tests in this pull request.

### References

- [VCF v4.5 specification](https://samtools.github.io/hts-specs/VCFv4.5.pdf)
  - The specification defines what the local-allele fields are.
- #277
  - This issue outlines the shortcomings of the current local alleles implementation.