### PR TITLE
Run on zarr-python v3 with zarr-format v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,25 @@ jobs:
           # We just run the CLI tests here because it doesn't require other upstream
           # packages like sgkit (which are tangled up with the numpy 2 dependency)
           python -m pytest tests/test_cli.py
+
+  test-zarr-version:
+    name: Test Zarr versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        zarr: ["zarr==2.18.3", "git+https://github.com/zarr-developers/zarr-python.git"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install '.[dev]'
+      - name: Install ${{ matrix.zarr }}
+        run: |
+          python -m pip install --pre '${{ matrix.zarr }}'
+      - name: Run tests
+        run: |
+          python -m pytest 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,4 +153,4 @@ jobs:
           python -m pip install 'zarr${{ matrix.zarr }}'
       - name: Run tests
         run: |
-          python -m pytest 
+          python -m pytest -k "not test_double_encode_partition"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        zarr: ["zarr==2.18.3", "git+https://github.com/zarr-developers/zarr-python.git"]
+        zarr: ["==2.18.3", ">=3"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -148,9 +148,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install '.[dev]'
-      - name: Install ${{ matrix.zarr }}
+      - name: Install zarr${{ matrix.zarr }}
         run: |
-          python -m pip install --pre '${{ matrix.zarr }}'
+          python -m pip install 'zarr${{ matrix.zarr }}'
       - name: Run tests
         run: |
           python -m pytest 

--- a/bio2zarr/plink.py
+++ b/bio2zarr/plink.py
@@ -86,7 +86,7 @@ def convert(
     # we're not using the best Blosc settings for genotypes here.
     default_compressor = numcodecs.Blosc(cname="zstd", clevel=7)
 
-    a = root.create_dataset(
+    a = root.array(
         "sample_id",
         data=bed.iid,
         shape=bed.iid.shape,
@@ -99,7 +99,7 @@ def convert(
 
     # TODO encode these in slices - but read them in one go to avoid
     # fetching repeatedly from bim file
-    a = root.create_dataset(
+    a = root.array(
         "variant_position",
         data=bed.bp_position,
         shape=bed.bp_position.shape,
@@ -111,7 +111,7 @@ def convert(
     logger.debug("encoded variant_position")
 
     alleles = np.stack([bed.allele_1, bed.allele_2], axis=1)
-    a = root.create_dataset(
+    a = root.array(
         "variant_allele",
         data=alleles,
         shape=alleles.shape,

--- a/bio2zarr/plink.py
+++ b/bio2zarr/plink.py
@@ -86,7 +86,7 @@ def convert(
     # we're not using the best Blosc settings for genotypes here.
     default_compressor = numcodecs.Blosc(cname="zstd", clevel=7)
 
-    a = root.array(
+    a = root.create_dataset(
         "sample_id",
         data=bed.iid,
         shape=bed.iid.shape,
@@ -99,7 +99,7 @@ def convert(
 
     # TODO encode these in slices - but read them in one go to avoid
     # fetching repeatedly from bim file
-    a = root.array(
+    a = root.create_dataset(
         "variant_position",
         data=bed.bp_position,
         shape=bed.bp_position.shape,
@@ -111,13 +111,13 @@ def convert(
     logger.debug("encoded variant_position")
 
     alleles = np.stack([bed.allele_1, bed.allele_2], axis=1)
-    a = root.array(
+    a = root.create_dataset(
         "variant_allele",
         data=alleles,
         shape=alleles.shape,
         dtype="str",
         compressor=default_compressor,
-        chunks=(variants_chunk_size,),
+        chunks=(variants_chunk_size, alleles.shape[1]),
     )
     a.attrs["_ARRAY_DIMENSIONS"] = ["variants", "alleles"]
     logger.debug("encoded variant_allele")

--- a/bio2zarr/vcf2zarr/vcz.py
+++ b/bio2zarr/vcf2zarr/vcz.py
@@ -572,7 +572,7 @@ class VcfZarrWriter:
     def encode_samples(self, root):
         if self.schema.samples != self.icf.metadata.samples:
             raise ValueError("Subsetting or reordering samples not supported currently")
-        array = root.create_dataset(
+        array = root.array(
             "sample_id",
             data=[sample.id for sample in self.schema.samples],
             shape=len(self.schema.samples),
@@ -584,7 +584,7 @@ class VcfZarrWriter:
         logger.debug("Samples done")
 
     def encode_contig_id(self, root):
-        array = root.create_dataset(
+        array = root.array(
             "contig_id",
             data=[contig.id for contig in self.schema.contigs],
             shape=len(self.schema.contigs),
@@ -593,7 +593,7 @@ class VcfZarrWriter:
         )
         array.attrs["_ARRAY_DIMENSIONS"] = ["contigs"]
         if all(contig.length is not None for contig in self.schema.contigs):
-            array = root.create_dataset(
+            array = root.array(
                 "contig_length",
                 data=[contig.length for contig in self.schema.contigs],
                 shape=len(self.schema.contigs),
@@ -605,7 +605,7 @@ class VcfZarrWriter:
     def encode_filter_id(self, root):
         # TODO need a way to store description also
         # https://github.com/sgkit-dev/vcf-zarr-spec/issues/19
-        array = root.create_dataset(
+        array = root.array(
             "filter_id",
             data=[filt.id for filt in self.schema.filters],
             shape=len(self.schema.filters),
@@ -955,7 +955,7 @@ class VcfZarrWriter:
         kwargs = {}
         if not zarr_v3():
             kwargs["dimension_separator"] = self.metadata.dimension_separator
-        array = root.create_dataset(
+        array = root.array(
             "region_index",
             data=index,
             shape=index.shape,

--- a/bio2zarr/vcf2zarr/verification.py
+++ b/bio2zarr/vcf2zarr/verification.py
@@ -77,7 +77,7 @@ def assert_info_val_equal(vcf_val, zarr_val, vcf_type):
     if vcf_type in ("String", "Character"):
         split = list(vcf_val.split(","))
         k = len(split)
-        if isinstance(zarr_val, str):
+        if isinstance(zarr_val, str) or zarr_val.ndim == 0:
             assert k == 1
             # Scalar
             assert vcf_val == zarr_val

--- a/bio2zarr/zarr_utils.py
+++ b/bio2zarr/zarr_utils.py
@@ -11,3 +11,9 @@ if zarr_v3():
     ZARR_FORMAT_KWARGS = dict(zarr_format=2)
 else:
     ZARR_FORMAT_KWARGS = dict()
+
+
+# See discussion in https://github.com/zarr-developers/zarr-python/issues/2529
+def first_dim_iter(z):
+    for chunk in range(z.cdata_shape[0]):
+        yield from z.blocks[chunk]

--- a/tests/test_vcz.py
+++ b/tests/test_vcz.py
@@ -9,6 +9,7 @@ import zarr
 from bio2zarr import core, vcf2zarr
 from bio2zarr.vcf2zarr import icf as icf_mod
 from bio2zarr.vcf2zarr import vcz as vcz_mod
+from bio2zarr.zarr_utils import zarr_v3
 
 
 @pytest.fixture(scope="module")
@@ -112,6 +113,9 @@ class TestJsonVersions:
             vcz_mod.VcfZarrWriterMetadata.fromdict(d)
 
 
+@pytest.mark.skipif(
+    zarr_v3(), reason="Zarr-python v3 does not support dimension_separator"
+)
 class TestEncodeDimensionSeparator:
     @pytest.mark.parametrize("dimension_separator", [None, "/"])
     def test_directories(self, tmp_path, icf_path, dimension_separator):


### PR DESCRIPTION
This is like #284, but the Zarr format is always v2, even when zarr-python v3 is being used. This is the approach I took for the Zarr v3 support in sgkit. This limits the scope of the changes, however there are still test failures under both zarr-python v2 and v3.

This still needs quite a lot of work, so I've opened it as a draft.

