### PR TITLE
Backward and forward-compatible changes to support zarr-python v3

### DIFF
--- a/bio2zarr/vcf2zarr/verification.py
+++ b/bio2zarr/vcf2zarr/verification.py
@@ -145,9 +145,7 @@ def assert_format_val_equal(vcf_val, zarr_val, vcf_type, vcf_number):
 
 
 def verify(vcf_path, zarr_path, show_progress=False):
-    store = zarr.DirectoryStore(zarr_path)
-
-    root = zarr.group(store=store)
+    root = zarr.open(store=zarr_path, mode="r")
     pos = root["variant_position"][:]
     allele = root["variant_allele"][:]
     chrom = root["contig_id"][:][root["variant_contig"][:]]

--- a/bio2zarr/zarr_utils.py
+++ b/bio2zarr/zarr_utils.py
@@ -1,0 +1,13 @@
+import zarr
+from packaging.version import Version
+
+
+def zarr_v3() -> bool:
+    return Version(zarr.__version__).major >= 3
+
+
+if zarr_v3():
+    # Use zarr format v2 even when running with zarr-python v3
+    ZARR_FORMAT_KWARGS = dict(zarr_format=2)
+else:
+    ZARR_FORMAT_KWARGS = dict()


### PR DESCRIPTION
This is a cutdown version of #288 with all the straightforward changes that work with zarr-python v2, but still has some failures with v3 (mainly around string handling).

It should be OK to merge this and tackle the other v3 changes in another PR.
