### PR TITLE
Use specified dimension separator for region index

### DIFF
--- a/bio2zarr/vcf2zarr/vcz.py
+++ b/bio2zarr/vcf2zarr/vcz.py
@@ -950,6 +950,7 @@ class VcfZarrWriter:
             shape=index.shape,
             dtype=index.dtype,
             compressor=numcodecs.Blosc("zstd", clevel=9, shuffle=0),
+            dimension_separator=self.metadata.dimension_separator,
         )
         array.attrs["_ARRAY_DIMENSIONS"] = [
             "region_index_values",


### PR DESCRIPTION
I noticed that I didn't set the dimension separator when doing #290.

I also noticed that `contig_id`, `contig_length`, `filter_id`, and `sample_id` don't have a dimension separator set - which OK as they are one-dimensional - but slightly inconsistent as there are other fields that are one-dimensional that do have it set, like `variant_id`. Should we just set it everywhere?