### PR TITLE
Reduce genotype mem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.1.2 2024-XX-XX
 
+- Reduce memory requirement for encoding genotypes with large sample sizes
+
 - Transpose default chunk sizes to 1000 variants and 10,000 samples (issue:300)
 
 - Add chunksize options to mkschema (issue:294)

--- a/tests/test_icf.py
+++ b/tests/test_icf.py
@@ -91,6 +91,19 @@ class TestSmallExample:
         assert icf["INFO/NS"].values == [None, None, 3, 3, 2, 3, 3, None, None]
 
 
+class TestWithGtHeaderNoGenotypes:
+    data_path = "tests/data/vcf/sample_no_genotypes_with_gt_header.vcf.gz"
+
+    @pytest.fixture(scope="class")
+    def icf(self, tmp_path_factory):
+        out = tmp_path_factory.mktemp("data") / "example.exploded"
+        return vcf2zarr.explode(out, [self.data_path])
+
+    def test_gts(self, icf):
+        values = icf["FORMAT/GT"].values
+        assert values == [None] * icf.num_records
+
+
 class TestIcfWriterExample:
     data_path = "tests/data/vcf/sample.vcf.gz"
 

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -508,6 +508,19 @@ class TestTriploidExample:
         nt.assert_array_equal(ds.call_genotype.values, [[[0, 0, 0]]])
 
 
+class TestWithGtHeaderNoGenotypes:
+    data_path = "tests/data/vcf/sample_no_genotypes_with_gt_header.vcf.gz"
+
+    @pytest.fixture(scope="class")
+    def ds(self, tmp_path_factory):
+        out = tmp_path_factory.mktemp("data") / "example.vcf.zarr"
+        vcf2zarr.convert([self.data_path], out, worker_processes=0)
+        return sg.load_dataset(out)
+
+    def test_gts(self, ds):
+        assert "call_genotype" not in ds
+
+
 class Test1000G2020Example:
     data_path = "tests/data/vcf/1kg_2020_chrM.vcf.gz"
 


### PR DESCRIPTION
Cuts down the peak memory for encoding large sample sizes by about a third