### PR TITLE
Add explicit documentation license statement

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,9 +2,8 @@
 # Learn more at https://jupyterbook.org/customize/config.html
 
 title: bio2zarr Documentation
-author: sgkit developers
+author: the sgkit developers
 logo: logo.png
-copyright: "2024"
 
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
@@ -22,12 +21,19 @@ repository:
 html:
   use_issues_button: true
   use_repository_button: true
+  extra_footer: |
+      <p>
+      Documentation available under the terms of the
+      <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</a> 
+      license.
+      </p>
 
 sphinx:
   extra_extensions:
     - sphinx_click.ext
     - sphinx.ext.todo
   config:
+    html_show_copyright: false
     # This is needed to make sure that text is output in single block from
     # bash cells.
     nb_merge_streams: true


### PR DESCRIPTION
Gigascience requested that we add an explicit statement of the license for documentation. This is the best way of doing this I could think of. We get this at the footer of every documentation page:
![Screenshot from 2025-03-05 11-10-03](https://github.com/user-attachments/assets/d21b53a3-fe89-4dc1-bb52-82b80128d505)

(The screenshot is a bit too big, just look at the bottom of the image! I also realised I missed a "the" after making this initially and have fixed in the PR)

I toyed briefly with using CC-BY or something to try and prevent LLMs from eating our docs, but then realised that we actively want our documentation to be incorporated into AI models (and anyway, it would almost certainly be ignored by scrapers).

@tomwhite @benjeffery, do you agree with this approach?