### PR TITLE
vcf_field -> source

### DIFF
--- a/bio2zarr/icf.py
+++ b/bio2zarr/icf.py
@@ -844,7 +844,6 @@ def convert_local_allele_field_types(fields):
     dimensions = gt.dimensions[:-1]
 
     la = vcz.ZarrArraySpec.new(
-        vcf_field=None,
         name="call_LA",
         dtype="i1",
         shape=gt.shape,
@@ -859,7 +858,7 @@ def convert_local_allele_field_types(fields):
     if ad is not None:
         # TODO check if call_LAD is in the list already
         ad.name = "call_LAD"
-        ad.vcf_field = None
+        ad.source = None
         ad.shape = (*shape, 2)
         ad.chunks = (*chunks, 2)
         ad.dimensions = (*dimensions, "local_alleles")
@@ -869,7 +868,7 @@ def convert_local_allele_field_types(fields):
     if pl is not None:
         # TODO check if call_LPL is in the list already
         pl.name = "call_LPL"
-        pl.vcf_field = None
+        pl.source = None
         pl.shape = (*shape, 3)
         pl.chunks = (*chunks, 3)
         pl.description += " (local-alleles)"
@@ -1060,13 +1059,13 @@ class IntermediateColumnarFormat(vcz.Source):
         def fixed_field_spec(
             name,
             dtype,
-            vcf_field=None,
+            source=None,
             shape=(m,),
             dimensions=("variants",),
             chunks=None,
         ):
             return vcz.ZarrArraySpec.new(
-                vcf_field=vcf_field,
+                source=source,
                 name=name,
                 dtype=dtype,
                 shape=shape,
@@ -1137,7 +1136,6 @@ class IntermediateColumnarFormat(vcz.Source):
             dimensions = ["variants", "samples"]
             array_specs.append(
                 vcz.ZarrArraySpec.new(
-                    vcf_field=None,
                     name="call_genotype_phased",
                     dtype="bool",
                     shape=list(shape),
@@ -1151,7 +1149,6 @@ class IntermediateColumnarFormat(vcz.Source):
             dimensions += ["ploidy"]
             array_specs.append(
                 vcz.ZarrArraySpec.new(
-                    vcf_field=None,
                     name="call_genotype",
                     dtype=gt_field.smallest_dtype(),
                     shape=list(shape),
@@ -1162,7 +1159,6 @@ class IntermediateColumnarFormat(vcz.Source):
             )
             array_specs.append(
                 vcz.ZarrArraySpec.new(
-                    vcf_field=None,
                     name="call_genotype_mask",
                     dtype="bool",
                     shape=list(shape),

--- a/bio2zarr/plink.py
+++ b/bio2zarr/plink.py
@@ -83,7 +83,7 @@ class PlinkFormat(vcz.Source):
 
         array_specs = [
             vcz.ZarrArraySpec.new(
-                vcf_field="position",
+                source="position",
                 name="variant_position",
                 dtype="i4",
                 shape=[m],
@@ -92,7 +92,6 @@ class PlinkFormat(vcz.Source):
                 description=None,
             ),
             vcz.ZarrArraySpec.new(
-                vcf_field=None,
                 name="variant_allele",
                 dtype="O",
                 shape=[m, 2],
@@ -101,7 +100,6 @@ class PlinkFormat(vcz.Source):
                 description=None,
             ),
             vcz.ZarrArraySpec.new(
-                vcf_field=None,
                 name="call_genotype_phased",
                 dtype="bool",
                 shape=[m, n],
@@ -113,7 +111,6 @@ class PlinkFormat(vcz.Source):
                 description=None,
             ),
             vcz.ZarrArraySpec.new(
-                vcf_field=None,
                 name="call_genotype",
                 dtype="i1",
                 shape=[m, n, 2],
@@ -126,7 +123,6 @@ class PlinkFormat(vcz.Source):
                 description=None,
             ),
             vcz.ZarrArraySpec.new(
-                vcf_field=None,
                 name="call_genotype_mask",
                 dtype="bool",
                 shape=[m, n, 2],

--- a/tests/test_vcz.py
+++ b/tests/test_vcz.py
@@ -340,7 +340,7 @@ class TestDefaultSchema:
             "dimensions": ("variants",),
             "description": "An identifier from the reference genome or an "
             "angle-bracketed ID string pointing to a contig in the assembly file",
-            "vcf_field": None,
+            "source": None,
             "compressor": {
                 "id": "blosc",
                 "cname": "zstd",
@@ -359,7 +359,7 @@ class TestDefaultSchema:
             "chunks": (1000, 10000, 2),
             "dimensions": ("variants", "samples", "ploidy"),
             "description": "",
-            "vcf_field": None,
+            "source": None,
             "compressor": {
                 "id": "blosc",
                 "cname": "zstd",
@@ -378,7 +378,7 @@ class TestDefaultSchema:
             "chunks": (1000, 10000, 2),
             "dimensions": ("variants", "samples", "ploidy"),
             "description": "",
-            "vcf_field": None,
+            "source": None,
             "compressor": {
                 "id": "blosc",
                 "cname": "zstd",
@@ -397,7 +397,7 @@ class TestDefaultSchema:
             "chunks": (1000, 10000, 2),
             "dimensions": ("variants", "samples", "ploidy"),
             "description": "",
-            "vcf_field": None,
+            "source": None,
             "compressor": {
                 "id": "blosc",
                 "cname": "zstd",
@@ -416,7 +416,7 @@ class TestDefaultSchema:
             "chunks": (1000, 10000),
             "dimensions": ("variants", "samples"),
             "description": "Genotype Quality",
-            "vcf_field": "FORMAT/GQ",
+            "source": "FORMAT/GQ",
             "compressor": {
                 "id": "blosc",
                 "cname": "zstd",
@@ -437,6 +437,7 @@ class TestLocalAllelesDefaultSchema:
     def test_call_LA(self, local_alleles_schema):
         d = get_field_dict(local_alleles_schema, "call_LA")
         assert d == {
+            "source": None,
             "name": "call_LA",
             "dtype": "i1",
             "shape": (9, 3, 2),
@@ -446,7 +447,6 @@ class TestLocalAllelesDefaultSchema:
                 "0-based indices into REF+ALT, indicating which alleles"
                 " are relevant (local) for the current sample"
             ),
-            "vcf_field": None,
             "compressor": {
                 "id": "blosc",
                 "cname": "zstd",


### PR DESCRIPTION
Rename `vcf_field` to `source` and make it optional in a `ZarrArraySpec`

Part of #351 