### PR TITLE
Add defaults to schema

### DIFF
--- a/bio2zarr/icf.py
+++ b/bio2zarr/icf.py
@@ -843,7 +843,7 @@ def convert_local_allele_field_types(fields):
     chunks = gt.chunks[:-1]
     dimensions = gt.dimensions[:-1]
 
-    la = vcz.ZarrArraySpec.new(
+    la = vcz.ZarrArraySpec(
         name="call_LA",
         dtype="i1",
         shape=gt.shape,
@@ -1064,7 +1064,12 @@ class IntermediateColumnarFormat(vcz.Source):
             dimensions=("variants",),
             chunks=None,
         ):
-            return vcz.ZarrArraySpec.new(
+            compressor = (
+                vcz.DEFAULT_ZARR_COMPRESSOR_BOOL.get_config()
+                if dtype == "bool"
+                else None
+            )
+            return vcz.ZarrArraySpec(
                 source=source,
                 name=name,
                 dtype=dtype,
@@ -1072,6 +1077,7 @@ class IntermediateColumnarFormat(vcz.Source):
                 description="",
                 dimensions=dimensions,
                 chunks=chunks or [schema_instance.variants_chunk_size],
+                compressor=compressor,
             )
 
         alt_field = self.fields["ALT"]
@@ -1135,7 +1141,7 @@ class IntermediateColumnarFormat(vcz.Source):
             ]
             dimensions = ["variants", "samples"]
             array_specs.append(
-                vcz.ZarrArraySpec.new(
+                vcz.ZarrArraySpec(
                     name="call_genotype_phased",
                     dtype="bool",
                     shape=list(shape),
@@ -1148,23 +1154,25 @@ class IntermediateColumnarFormat(vcz.Source):
             chunks += [ploidy]
             dimensions += ["ploidy"]
             array_specs.append(
-                vcz.ZarrArraySpec.new(
+                vcz.ZarrArraySpec(
                     name="call_genotype",
                     dtype=gt_field.smallest_dtype(),
                     shape=list(shape),
                     chunks=list(chunks),
                     dimensions=list(dimensions),
                     description="",
+                    compressor=vcz.DEFAULT_ZARR_COMPRESSOR_GENOTYPES.get_config(),
                 )
             )
             array_specs.append(
-                vcz.ZarrArraySpec.new(
+                vcz.ZarrArraySpec(
                     name="call_genotype_mask",
                     dtype="bool",
                     shape=list(shape),
                     chunks=list(chunks),
                     dimensions=list(dimensions),
                     description="",
+                    compressor=vcz.DEFAULT_ZARR_COMPRESSOR_BOOL.get_config(),
                 )
             )
 

--- a/bio2zarr/plink.py
+++ b/bio2zarr/plink.py
@@ -82,7 +82,7 @@ class PlinkFormat(vcz.Source):
         )
 
         array_specs = [
-            vcz.ZarrArraySpec.new(
+            vcz.ZarrArraySpec(
                 source="position",
                 name="variant_position",
                 dtype="i4",
@@ -91,7 +91,7 @@ class PlinkFormat(vcz.Source):
                 chunks=[schema_instance.variants_chunk_size],
                 description=None,
             ),
-            vcz.ZarrArraySpec.new(
+            vcz.ZarrArraySpec(
                 name="variant_allele",
                 dtype="O",
                 shape=[m, 2],
@@ -99,7 +99,7 @@ class PlinkFormat(vcz.Source):
                 chunks=[schema_instance.variants_chunk_size, 2],
                 description=None,
             ),
-            vcz.ZarrArraySpec.new(
+            vcz.ZarrArraySpec(
                 name="call_genotype_phased",
                 dtype="bool",
                 shape=[m, n],
@@ -109,8 +109,9 @@ class PlinkFormat(vcz.Source):
                     schema_instance.samples_chunk_size,
                 ],
                 description=None,
+                compressor=vcz.DEFAULT_ZARR_COMPRESSOR_BOOL.get_config(),
             ),
-            vcz.ZarrArraySpec.new(
+            vcz.ZarrArraySpec(
                 name="call_genotype",
                 dtype="i1",
                 shape=[m, n, 2],
@@ -121,8 +122,9 @@ class PlinkFormat(vcz.Source):
                     2,
                 ],
                 description=None,
+                compressor=vcz.DEFAULT_ZARR_COMPRESSOR_BOOL.get_config(),
             ),
-            vcz.ZarrArraySpec.new(
+            vcz.ZarrArraySpec(
                 name="call_genotype_mask",
                 dtype="bool",
                 shape=[m, n, 2],
@@ -133,6 +135,7 @@ class PlinkFormat(vcz.Source):
                     2,
                 ],
                 description=None,
+                compressor=vcz.DEFAULT_ZARR_COMPRESSOR_BOOL.get_config(),
             ),
         ]
         schema_instance.fields = array_specs


### PR DESCRIPTION
Add a `defaults` section to the schema. Also move the resposibilty for specific compressor settings to the `generate_schema` methods.
Part of #351