### PR TITLE
Don't store original VCF header in vcz

### DIFF
--- a/bio2zarr/icf.py
+++ b/bio2zarr/icf.py
@@ -891,8 +891,6 @@ class IntermediateColumnarFormat(vcz.Source):
         # directory is either a WIP or the wrong format.
         with open(self.path / "metadata.json") as f:
             self.metadata = IcfMetadata.fromdict(json.load(f))
-        with open(self.path / "header.txt") as f:
-            self.vcf_header = f.read()
         self.compressor = numcodecs.get_codec(self.metadata.compressor)
         self.fields = {}
         partition_num_records = [
@@ -970,9 +968,7 @@ class IntermediateColumnarFormat(vcz.Source):
 
     @property
     def root_attrs(self):
-        return {
-            "vcf_header": self.vcf_header,
-        }
+        return {}
 
     def iter_id(self, start, stop):
         for value in self.fields["ID"].iter_values(start, stop):
@@ -1299,10 +1295,8 @@ class IntermediateColumnarFormatWriter:
 
         self.mkdirs()
 
-        # Note: this is needed for the current version of the vcfzarr spec, but it's
-        # probably going to be dropped.
+        # Note: the header is no longer stored in vcz, but keep in icf.
         # https://github.com/pystatgen/vcf-zarr-spec/issues/15
-        # May be useful to keep lying around still though?
         logger.info("Writing VCF header")
         with open(self.path / "header.txt", "w") as f:
             f.write(header)

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -2,7 +2,6 @@ import collections
 import pathlib
 import re
 
-import cyvcf2
 import numpy as np
 import numpy.testing as nt
 import pytest
@@ -52,10 +51,6 @@ class TestSmallExample:
                 [True, False, False],
             ],
         )
-
-    def test_header(self, ds):
-        vcf = cyvcf2.VCF(self.data_path)
-        assert ds.attrs["vcf_header"] == vcf.raw_header
 
     def test_source(self, ds):
         assert ds.attrs["source"] == f"bio2zarr-{provenance.__version__}"


### PR DESCRIPTION
We probably shouldn't merge this until after the next bio2zarr release, and after bumping the VCZ spec version to 0.4 (see https://github.com/sgkit-dev/vcf-zarr-spec/pull/39).