### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         # Use macos-13 because pip binary packages for ARM aren't
         # available for many dependencies
         os: [macos-13, macos-14, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         exclude:
           # Just run macos tests on one Python version
           - os: macos-13
@@ -34,8 +34,6 @@ jobs:
             python-version: "3.11"
           - os: macos-13
             python-version: "3.12"
-          - os: macos-14
-            python-version: "3.9"
           - os: macos-14
             python-version: "3.10"
           - os: macos-14

--- a/bio2zarr/core.py
+++ b/bio2zarr/core.py
@@ -7,10 +7,8 @@ import math
 import multiprocessing
 import os
 import os.path
-import sys
 import threading
 import time
-import warnings
 
 import humanfriendly
 import numcodecs
@@ -256,22 +254,6 @@ def setup_progress_counter(counter):
     _progress_counter = counter
 
 
-def warn_py39_mac():
-    if sys.platform == "darwin" and sys.version_info[:2] == (3, 9):
-        warnings.warn(
-            "There is a known issue with bio2zarr on MacOS Python 3.9 "
-            "in which OS-level named semaphores are leaked. "
-            "You will also probably see warnings like 'There appear to be N "
-            "leaked semaphore objects at shutdown'. "
-            "While this is likely harmless for a few runs, it could lead to "
-            "issues if you do a lot of conversion. To get prevent this issue "
-            "either: (1) use --worker-processes=0 or (2) upgrade to a newer "
-            "Python version. See https://github.com/sgkit-dev/bio2zarr/issues/209 "
-            "for more details.",
-            stacklevel=2,
-        )
-
-
 class ParallelWorkManager(contextlib.AbstractContextManager):
     def __init__(self, worker_processes=1, progress_config=None):
         # Need to specify this explicitly to suppport Macs and
@@ -284,7 +266,6 @@ class ParallelWorkManager(contextlib.AbstractContextManager):
             # production. See note on the SynchronousExecutor class.
             self.executor = SynchronousExecutor()
         else:
-            warn_py39_mac()
             self.executor = cf.ProcessPoolExecutor(
                 max_workers=worker_processes,
                 mp_context=ctx,

--- a/bio2zarr/typing.py
+++ b/bio2zarr/typing.py
@@ -1,4 +1,3 @@
 from pathlib import Path
-from typing import Union
 
-PathType = Union[str, Path]
+PathType = str | Path

--- a/bio2zarr/vcf.py
+++ b/bio2zarr/vcf.py
@@ -638,7 +638,8 @@ class IntermediateColumnarFormatField:
         chunk_cumulative_records = self.chunk_record_index(partition_id)
         chunk_num_records = np.diff(chunk_cumulative_records)
         for count, cumulative in zip(
-            chunk_num_records[start_chunk:], chunk_cumulative_records[start_chunk + 1 :]
+            chunk_num_records[start_chunk:],
+            chunk_cumulative_records[start_chunk + 1 :],
         ):
             path = partition_path / f"{cumulative}"
             chunk = self.read_chunk(path)

--- a/bio2zarr/vcf_utils.py
+++ b/bio2zarr/vcf_utils.py
@@ -7,7 +7,7 @@ import struct
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import IO, Any, Optional, Union
+from typing import IO, Any
 
 import cyvcf2
 import humanfriendly
@@ -33,7 +33,7 @@ def get_file_offset(vfp: int) -> int:
     return vfp >> 16 & address_mask
 
 
-def read_bytes_as_value(f: IO[Any], fmt: str, nodata: Optional[Any] = None) -> Any:
+def read_bytes_as_value(f: IO[Any], fmt: str, nodata: Any | None = None) -> Any:
     """Read bytes using a `struct` format string and return the unpacked data value.
 
     Parameters
@@ -85,8 +85,8 @@ class Region:
     """
 
     contig: str
-    start: Optional[int] = None
-    end: Optional[int] = None
+    start: int | None = None
+    end: int | None = None
 
     def __post_init__(self):
         assert self.contig is not None
@@ -197,9 +197,7 @@ def get_first_locus_in_bin(csi: CSIIndex, bin: int) -> int:
     return (bin - first_bin_on_level) * (max_span // level_size) + 1
 
 
-def read_csi(
-    file: PathType, storage_options: Optional[dict[str, str]] = None
-) -> CSIIndex:
+def read_csi(file: PathType, storage_options: dict[str, str] | None = None) -> CSIIndex:
     """Parse a CSI file into a `CSIIndex` object.
 
     Parameters
@@ -314,7 +312,7 @@ class TabixIndex:
 
 
 def read_tabix(
-    file: PathType, storage_options: Optional[dict[str, str]] = None
+    file: PathType, storage_options: dict[str, str] | None = None
 ) -> TabixIndex:
     """Parse a tabix file into a `TabixIndex` object.
 
@@ -512,8 +510,8 @@ class VcfFile(contextlib.AbstractContextManager):
 
     def partition_into_regions(
         self,
-        num_parts: Optional[int] = None,
-        target_part_size: Union[None, int, str] = None,
+        num_parts: int | None = None,
+        target_part_size: None | int | str = None,
     ):
         if num_parts is None and target_part_size is None:
             raise ValueError("One of num_parts or target_part_size must be specified")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "cyvcf2",
   "bed_reader",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: Apache Software License",
@@ -37,7 +37,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -55,6 +54,7 @@ vcfpartition = "bio2zarr.cli:vcfpartition"
 
 [project.optional-dependencies]
 dev = [
+  "click>=8.2.0",
   "hypothesis-vcf",
   "msprime",
   "pysam",
@@ -76,8 +76,8 @@ testpaths = "tests"
 addopts = "--cov=bio2zarr --cov-report term-missing"
 
 [tool.ruff]
-# Assume Python 3.9
-target-version = "py39"
+# Assume Python 3.10
+target-version = "py310"
 
 # Same as Black.
 line-length = 88
@@ -86,7 +86,8 @@ indent-width = 4
 [tool.ruff.lint]
 select = ["E", "F", "B", "W", "I", "N", "UP", "A", "PT"]
 #Allow uppercase names for e.g. call_AD
-ignore = ["N806", "N802", "A001", "A002", "RUF"]
+#Don't add strict=False to zips (B905)
+ignore = ["N806", "N802", "A001", "A002", "B905", "RUF"]
 
 fixable = ["ALL"]
 unfixable = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,7 +87,7 @@ class TestWithMocks:
     @mock.patch("bio2zarr.vcf.explode")
     def test_vcf_explode(self, mocked, tmp_path, progress, flag):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path} {flag}",
@@ -104,7 +104,7 @@ class TestWithMocks:
     @mock.patch("bio2zarr.vcf.explode")
     def test_vcf_explode_compressor(self, mocked, tmp_path, compressor):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path} -C {compressor}",
@@ -127,7 +127,7 @@ class TestWithMocks:
     @mock.patch("bio2zarr.vcf.explode_init")
     def test_vcf_dexplode_init_compressor(self, mocked, tmp_path, compressor):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"dexplode-init {self.vcf_path} {icf_path} -n 1 -C {compressor}",
@@ -150,7 +150,7 @@ class TestWithMocks:
     @pytest.mark.parametrize("compressor", ["LZ4", "asdf"])
     @mock.patch("bio2zarr.vcf.explode")
     def test_vcf_explode_bad_compressor(self, mocked, tmp_path, compressor):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         result = runner.invoke(
             cli.vcf2zarr_main,
@@ -164,7 +164,7 @@ class TestWithMocks:
     @mock.patch("bio2zarr.vcf.explode")
     def test_vcf_explode_multiple_vcfs(self, mocked, tmp_path):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {self.vcf_path} {icf_path}",
@@ -182,7 +182,7 @@ class TestWithMocks:
     def test_vcf_explode_overwrite_icf_confirm_yes(self, mocked, tmp_path, response):
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path}",
@@ -203,7 +203,7 @@ class TestWithMocks:
         icf_path.mkdir()
         zarr_path = tmp_path / "zarr"
         zarr_path.mkdir()
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"encode {icf_path} {zarr_path}",
@@ -222,7 +222,7 @@ class TestWithMocks:
     def test_vcf_explode_overwrite_icf_force(self, mocked, tmp_path, force_arg):
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path} {force_arg}",
@@ -242,7 +242,7 @@ class TestWithMocks:
         icf_path.mkdir()
         zarr_path = tmp_path / "zarr"
         zarr_path.mkdir()
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"encode {icf_path} {zarr_path} {force_arg}",
@@ -260,7 +260,7 @@ class TestWithMocks:
     @mock.patch("bio2zarr.vcf.explode")
     def test_vcf_explode_missing_vcf(self, mocked, tmp_path):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode no_such_file {icf_path}",
@@ -276,7 +276,7 @@ class TestWithMocks:
     def test_vcf_explode_overwrite_icf_confirm_no(self, mocked, tmp_path, response):
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path}",
@@ -290,7 +290,7 @@ class TestWithMocks:
     @mock.patch("bio2zarr.vcf.explode")
     def test_vcf_explode_missing_and_existing_vcf(self, mocked, tmp_path):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} no_such_file {icf_path}",
@@ -304,7 +304,7 @@ class TestWithMocks:
     @pytest.mark.parametrize(("progress", "flag"), [(True, "-P"), (False, "-Q")])
     @mock.patch("bio2zarr.vcf.explode_init", return_value=FakeWorkSummary(5))
     def test_vcf_dexplode_init(self, mocked, tmp_path, progress, flag):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         result = runner.invoke(
             cli.vcf2zarr_main,
@@ -328,7 +328,7 @@ class TestWithMocks:
     def test_vcf_dexplode_init_bad_num_partitions(
         self, mocked, tmp_path, num_partitions
     ):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         result = runner.invoke(
             cli.vcf2zarr_main,
@@ -341,7 +341,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.explode_init", return_value=5)
     def test_vcf_dexplode_init_no_partitions(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         result = runner.invoke(
             cli.vcf2zarr_main,
@@ -354,7 +354,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.explode_partition")
     def test_vcf_dexplode_partition(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
         result = runner.invoke(
@@ -371,7 +371,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.explode_partition")
     def test_vcf_dexplode_partition_one_based(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
         result = runner.invoke(
@@ -388,7 +388,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.explode_partition")
     def test_vcf_dexplode_partition_missing_dir(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         result = runner.invoke(
             cli.vcf2zarr_main,
@@ -403,7 +403,7 @@ class TestWithMocks:
     @pytest.mark.parametrize("partition", ["-- -1", "asdf", "1.112"])
     @mock.patch("bio2zarr.vcf.explode_partition")
     def test_vcf_dexplode_partition_bad_partition(self, mocked, tmp_path, partition):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
         result = runner.invoke(
@@ -418,7 +418,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.explode_finalise")
     def test_vcf_dexplode_finalise(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main, f"dexplode-finalise {tmp_path}", catch_exceptions=False
         )
@@ -429,7 +429,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.inspect")
     def test_inspect(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main, f"inspect {tmp_path}", catch_exceptions=False
         )
@@ -440,7 +440,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.mkschema")
     def test_mkschema(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"mkschema {tmp_path} --variants-chunk-size=3 --samples-chunk-size=4",
@@ -460,7 +460,7 @@ class TestWithMocks:
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
         zarr_path = tmp_path / "zarr"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"encode {icf_path} {zarr_path} {flag}",
@@ -483,7 +483,7 @@ class TestWithMocks:
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
         zarr_path = tmp_path / "zarr"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"dencode-init {icf_path} {zarr_path} -n 10 {flag}",
@@ -503,7 +503,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.encode_init", return_value=5)
     def test_vcf_dencode_init_no_partitions(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         icf_path = tmp_path / "icf"
         icf_path.mkdir()
         zarr_path = tmp_path / "zarr"
@@ -518,7 +518,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.encode_partition")
     def test_vcf_dencode_partition(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         zarr_path = tmp_path / "zarr"
         zarr_path.mkdir()
         result = runner.invoke(
@@ -535,7 +535,7 @@ class TestWithMocks:
 
     @mock.patch("bio2zarr.vcf.encode_partition")
     def test_vcf_dencode_partition_one_based(self, mocked, tmp_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         zarr_path = tmp_path / "zarr"
         zarr_path.mkdir()
         result = runner.invoke(
@@ -553,7 +553,7 @@ class TestWithMocks:
     @pytest.mark.parametrize(("progress", "flag"), [(True, "-P"), (False, "-Q")])
     @mock.patch("bio2zarr.vcf.encode_finalise")
     def test_vcf_dencode_finalise(self, mocked, tmp_path, progress, flag):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"dencode-finalise {tmp_path} {flag}",
@@ -569,7 +569,7 @@ class TestWithMocks:
     @pytest.mark.parametrize(("progress", "flag"), [(True, "-P"), (False, "-Q")])
     @mock.patch("bio2zarr.vcf.convert")
     def test_convert_vcf(self, mocked, progress, flag):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"convert {self.vcf_path} zarr_path {flag}",
@@ -591,7 +591,7 @@ class TestWithMocks:
     def test_vcf_convert_overwrite_zarr_confirm_no(self, mocked, tmp_path, response):
         zarr_path = tmp_path / "zarr"
         zarr_path.mkdir()
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"convert {self.vcf_path} {zarr_path}",
@@ -605,7 +605,7 @@ class TestWithMocks:
     @pytest.mark.parametrize(("progress", "flag"), [(True, "-P"), (False, "-Q")])
     @mock.patch("bio2zarr.plink.convert")
     def test_convert_plink(self, mocked, progress, flag):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.plink2zarr, ["convert", "in", "out", flag], catch_exceptions=False
         )
@@ -621,7 +621,7 @@ class TestWithMocks:
     def test_vcf_convert_overwrite_zarr_confirm_yes(self, mocked, tmp_path, response):
         zarr_path = tmp_path / "zarr"
         zarr_path.mkdir()
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"convert {self.vcf_path} {zarr_path}",
@@ -642,7 +642,7 @@ class TestVcfEndToEnd:
     @pytest.mark.parametrize("one_based", [False, True])
     def test_dexplode(self, tmp_path, one_based):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"dexplode-init {self.vcf_path} {icf_path} -n 5 --json -Q",
@@ -674,7 +674,7 @@ class TestVcfEndToEnd:
 
     def test_explode(self, tmp_path):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path}",
@@ -690,7 +690,7 @@ class TestVcfEndToEnd:
 
     def test_mkschema(self, tmp_path):
         icf_path = tmp_path / "icf"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path}",
@@ -713,7 +713,7 @@ class TestVcfEndToEnd:
         local_alleles_flag = {True: "--local-alleles", False: "--no-local-alleles"}[
             local_alleles
         ]
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path}",
@@ -736,7 +736,7 @@ class TestVcfEndToEnd:
     def test_encode(self, tmp_path):
         icf_path = tmp_path / "icf"
         zarr_path = tmp_path / "zarr"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path}",
@@ -758,7 +758,7 @@ class TestVcfEndToEnd:
     def test_dencode(self, tmp_path, one_based):
         icf_path = tmp_path / "icf"
         zarr_path = tmp_path / "zarr"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"explode {self.vcf_path} {icf_path}",
@@ -795,7 +795,7 @@ class TestVcfEndToEnd:
 
     def test_convert(self, tmp_path):
         zarr_path = tmp_path / "zarr"
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"convert {self.vcf_path} {zarr_path}",
@@ -813,7 +813,7 @@ class TestVcfEndToEnd:
 class TestBadPaths:
     @pytest.mark.parametrize("bad_path", ["PPP", "/dev/no_such_thing"])
     def test_inspect(self, bad_path):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcf2zarr_main,
             f"inspect {bad_path}",
@@ -828,7 +828,7 @@ class TestVcfPartition:
     paths = (path, "tests/data/vcf/1kg_2020_chrM.vcf.gz")
 
     def test_num_parts(self):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcfpartition, [self.path, "-n", "5"], catch_exceptions=False
         )
@@ -843,7 +843,7 @@ class TestVcfPartition:
         ]
 
     def test_part_size(self):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcfpartition, [self.path, "-s", "512K"], catch_exceptions=False
         )
@@ -861,21 +861,21 @@ class TestVcfPartition:
         ]
 
     def test_no_part_spec(self):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(cli.vcfpartition, [self.path], catch_exceptions=False)
         assert result.exit_code != 0
         assert result.stdout == ""
         assert len(result.stderr) > 0
 
     def test_no_args(self):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(cli.vcfpartition, [], catch_exceptions=False)
         assert result.exit_code != 0
         assert result.stdout == ""
         assert len(result.stderr) > 0
 
     def test_num_parts_multiple_vcfs(self):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcfpartition, [*self.paths, "-n", "5"], catch_exceptions=False
         )
@@ -888,7 +888,7 @@ class TestVcfPartition:
         ]
 
     def test_part_size_multiple_vcfs(self):
-        runner = ct.CliRunner(mix_stderr=False)
+        runner = ct.CliRunner()
         result = runner.invoke(
             cli.vcfpartition, [*self.paths, "-s", "512K"], catch_exceptions=False
         )
@@ -911,7 +911,7 @@ class TestVcfPartition:
     "cmd", [main.bio2zarr, cli.vcf2zarr_main, cli.plink2zarr, cli.vcfpartition]
 )
 def test_version(cmd):
-    runner = ct.CliRunner(mix_stderr=False)
+    runner = ct.CliRunner()
     result = runner.invoke(cmd, ["--version"], catch_exceptions=False)
     s = f"version {provenance.__version__}\n"
     assert result.stdout.endswith(s)


### PR DESCRIPTION
Recent dependancy updates (specifically `click` as shown in #374) are no longer supporting 3.9. To avoid pinning or writing code to deal with multiple `click` versions, it is probably time to drop 3.9.