### PR TITLE
Add zipzarr command for (un)packing Zarr zip stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Add zip VCZ output support to CLI and Python APIs (#462).
 
+- Add ``zipzarr`` CLI to make converting between .vcz and .vcz.zip
+  straightforward (#470)
+
 - Add in-memory VCZ output to Python API; ``convert()`` functions
   (``vcf``, ``plink``, ``tskit``) and ``vcf.encode()`` now return a
   ``zarr.Group`` (#462).

--- a/bio2zarr/__main__.py
+++ b/bio2zarr/__main__.py
@@ -18,6 +18,7 @@ bio2zarr.add_command(cli.vcf2zarr_main)
 bio2zarr.add_command(cli.plink2zarr_main)
 bio2zarr.add_command(cli.tskit2zarr_main)
 bio2zarr.add_command(cli.vcfpartition)
+bio2zarr.add_command(cli.zipzarr)
 
 if __name__ == "__main__":
     bio2zarr()

--- a/bio2zarr/cli.py
+++ b/bio2zarr/cli.py
@@ -8,7 +8,7 @@ import coloredlogs
 import numcodecs
 import tabulate
 
-from . import core, plink, provenance, vcf_utils
+from . import core, plink, provenance, vcf_utils, zarr_utils
 from . import tskit as tskit_mod
 from . import vcf as vcf_mod
 
@@ -655,6 +655,71 @@ def vcfpartition(vcfs, verbose, num_partitions, partition_size):
         )
         for region in regions:
             click.echo(f"{region}\t{vcf_path}")
+
+
+@click.command
+@version
+@click.argument("src", type=click.Path(exists=True))
+@click.argument("dest", type=click.Path(), required=False)
+@click.option(
+    "-u",
+    "--unzip",
+    is_flag=True,
+    flag_value=True,
+    help="Unzip SRC (a .zip archive) into DEST (a directory).",
+)
+@click.option(
+    "-k",
+    "--keep",
+    is_flag=True,
+    flag_value=True,
+    help="Keep (don't delete) the source after a successful operation.",
+)
+@force
+@verbose
+@progress
+def zipzarr(src, dest, unzip, keep, force, verbose, progress):
+    """
+    Pack a Zarr directory store into a single .zip archive.
+
+    By default, packages the directory SRC into the .zip file DEST. If DEST
+    is omitted, it defaults to SRC with a ``.zip`` suffix appended.
+
+    With -u/--unzip, the direction is reversed: SRC is a .zip archive and
+    DEST is the directory it should be extracted into. If DEST is omitted,
+    it defaults to SRC with the trailing ``.zip`` stripped.
+
+    On success, SRC is removed (like gzip). Pass -k/--keep to preserve it.
+    zipzarr does not check whether the input is a well-formed Zarr store --
+    it will zip any directory and unzip any archive.
+    """
+    setup_logging(verbose)
+    src_path = pathlib.Path(src)
+    if unzip:
+        if dest is None:
+            if src_path.suffix != ".zip":
+                raise click.UsageError(
+                    f"Cannot derive output path: {src} does not end in .zip. "
+                    "Provide DEST explicitly."
+                )
+            dest = str(src_path.with_suffix(""))
+        check_overwrite_dir(dest, force)
+        logger.info(f"Unzipping {src} -> {dest}")
+        zarr_utils.unzip_zarr(src, dest, show_progress=progress)
+        if not keep:
+            logger.info(f"Removing source {src}")
+            os.remove(src_path)
+    else:
+        if dest is None:
+            dest = f"{src_path}.zip"
+        dest_path = pathlib.Path(dest)
+        if dest_path.exists() and not force:
+            raise click.UsageError(f"{dest} already exists. Use --force to overwrite.")
+        logger.info(f"Zipping {src} -> {dest}")
+        zarr_utils.zip_zarr(src, dest, show_progress=progress)
+        if not keep:
+            logger.info(f"Removing source {src}")
+            shutil.rmtree(src_path)
 
 
 @click.command(name="convert")

--- a/bio2zarr/zarr_utils.py
+++ b/bio2zarr/zarr_utils.py
@@ -5,6 +5,7 @@ import zipfile
 
 import numcodecs
 import numpy as np
+import tqdm
 import zarr
 from zarr.codecs.blosc import BloscCodec, BloscShuffle
 
@@ -223,14 +224,30 @@ def move_chunks(src_path, dest_path, partition, name):
         os.rename(chunk_file, dest / chunk_file.name)
 
 
-def zip_zarr(dir_path, zip_path):
+def zip_zarr(dir_path, zip_path, *, show_progress=False):
     """Create a zip archive of a zarr directory store."""
     dir_path = pathlib.Path(dir_path)
     zip_path = pathlib.Path(zip_path)
+    files = sorted(p for p in dir_path.rglob("*") if p.is_file())
+    logger.info(f"Zipping {len(files)} files from {dir_path} to {zip_path}")
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
-        for file in sorted(dir_path.rglob("*")):
-            if file.is_file():
-                zf.write(file, file.relative_to(dir_path))
+        for file in tqdm.tqdm(
+            files, desc="     Zip", unit=" files", disable=not show_progress
+        ):
+            zf.write(file, file.relative_to(dir_path))
+
+
+def unzip_zarr(zip_path, dir_path, *, show_progress=False):
+    """Extract a zip archive of a zarr directory store."""
+    zip_path = pathlib.Path(zip_path)
+    dir_path = pathlib.Path(dir_path)
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        members = zf.namelist()
+        logger.info(f"Unzipping {len(members)} files from {zip_path} to {dir_path}")
+        for member in tqdm.tqdm(
+            members, desc="   Unzip", unit=" files", disable=not show_progress
+        ):
+            zf.extract(member, dir_path)
 
 
 def dir_to_memory_store(dir_path, mode="r"):

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -18,3 +18,6 @@ chapters:
 - file: vcfpartition/overview
   sections:
   - file: vcfpartition/cli_ref
+- file: zipzarr/overview
+  sections:
+  - file: zipzarr/cli_ref

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -22,6 +22,11 @@ files to other formats, see [vcztools](https://github.com/sgkit-dev/vcztools).
   VCF into a given number of partitions. This is useful for
   parallel processing of VCF data.
 
+- {ref}`sec-zipzarr` is a utility for zipping/unzipping Zarr directory
+  stores. There can be significant advantages to using a single
+  zipped VCZ over a large directory tree, and this utility makes it
+  straightforward to switch between the two representations.
+
 ## Development status
 
 `bio2zarr` is in development, contributions, feedback and issues are welcome

--- a/docs/zipzarr/cli_ref.md
+++ b/docs/zipzarr/cli_ref.md
@@ -1,0 +1,9 @@
+# CLI Reference
+
+
+```{eval-rst}
+.. _cmd-zipzarr:
+.. click:: bio2zarr.cli:zipzarr
+   :prog: zipzarr
+   :nested: full
+```

--- a/docs/zipzarr/overview.md
+++ b/docs/zipzarr/overview.md
@@ -1,0 +1,74 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Bash
+  language: bash
+  name: bash
+---
+(sec-zipzarr)=
+# zipzarr
+
+## Overview
+
+The {ref}`cmd-zipzarr` utility packs a Zarr directory store into a single
+``.zip`` file, and can reverse the operation with ``-u/--unzip``.
+
+Output paths default to SRC with ``.zip`` appended (or stripped, under
+``-u``), and the source is removed on success unless ``-k/--keep`` is
+passed — mirroring ``gzip``.
+
+:::{warning}
+``zipzarr`` does **not** check whether the input is a Zarr store. It
+will zip any directory and unzip any archive; it is your responsibility
+to ensure the input is a well-formed Zarr store.
+:::
+
+### Zipping a directory store
+
+Given a Zarr directory store ``sample.vcz``, pack it into a single file:
+
+```
+zipzarr sample.vcz sample.vcz.zip
+```
+
+If you omit the output path, ``zipzarr`` appends ``.zip`` to the source
+and removes the source directory after zipping. Pass ``-k/--keep`` to keep
+it:
+
+```
+zipzarr sample.vcz        # writes sample.vcz.zip, removes sample.vcz
+zipzarr -k sample.vcz     # writes sample.vcz.zip, keeps sample.vcz
+```
+
+### Unzipping a zipped store
+
+To go the other way, pass ``-u/--unzip`` and swap the argument order so
+that the archive comes first and the target directory second:
+
+```
+zipzarr -u sample.vcz.zip sample-roundtrip.vcz
+```
+
+If you omit the output path, ``zipzarr`` strips the trailing ``.zip`` and
+removes the zip after extracting. Pass ``-k/--keep`` to keep it:
+
+```
+zipzarr -u sample.vcz.zip       # writes sample.vcz, removes the .zip
+zipzarr -u -k sample.vcz.zip    # writes sample.vcz, keeps the .zip
+```
+
+If SRC does not end in ``.zip``, you must provide the output path
+explicitly.
+
+### Options
+
+- ``--progress/--no-progress`` shows or hides a progress bar. Progress is
+  on by default.
+- ``--force`` overwrites an existing destination. Without it, ``zipzarr``
+  refuses to clobber an existing file or directory.
+- ``-k/--keep`` preserves the source after a successful operation.
+  Without it, SRC is removed on success (like ``gzip``).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ vcf2zarr = "bio2zarr.cli:vcf2zarr_main"
 vcfpartition = "bio2zarr.cli:vcfpartition"
 tskit2zarr = "bio2zarr.cli:tskit2zarr_main"
 plink2zarr = "bio2zarr.cli:plink2zarr_main"
+zipzarr = "bio2zarr.cli:zipzarr"
 
 [project.optional-dependencies]
 tskit = ["tskit>=1"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import shutil
 import sys
 from unittest import mock
 
@@ -1280,3 +1281,169 @@ def test_main_entry_point():
     assert "plink2zarr" in result.stdout
     assert "tskit2zarr" in result.stdout
     assert "vcfpartition" in result.stdout
+    assert "zipzarr" in result.stdout
+
+
+def _make_sample_zarr(path):
+    root = zarr.open(store=path, mode="w", zarr_format=2)
+    root.attrs["test_attr"] = "hello"
+    root.create_array("data", data=np.array([1, 2, 3]))
+
+
+class TestZipZarr:
+    def test_zip_roundtrip(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        zip_path = tmp_path / "store.zip"
+        out = tmp_path / "store-out.zarr"
+        _make_sample_zarr(src)
+
+        runner = ct.CliRunner()
+        result = runner.invoke(
+            cli.zipzarr,
+            [str(src), str(zip_path), "-k"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert zip_path.exists()
+        assert src.exists()
+
+        result = runner.invoke(
+            cli.zipzarr,
+            ["-u", "-k", str(zip_path), str(out)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert zip_path.exists()
+        root = zarr.open(store=out, mode="r")
+        assert root.attrs["test_attr"] == "hello"
+        np.testing.assert_array_equal(root["data"][:], [1, 2, 3])
+
+    def test_zip_refuses_overwrite(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        zip_path = tmp_path / "store.zip"
+        _make_sample_zarr(src)
+        zip_path.write_bytes(b"existing")
+
+        runner = ct.CliRunner()
+        result = runner.invoke(cli.zipzarr, [str(src), str(zip_path)])
+        assert result.exit_code != 0
+        assert "already exists" in result.stderr
+        assert zip_path.read_bytes() == b"existing"
+        assert src.exists()
+
+    def test_zip_force_overwrites(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        zip_path = tmp_path / "store.zip"
+        _make_sample_zarr(src)
+        zip_path.write_bytes(b"existing")
+
+        runner = ct.CliRunner()
+        result = runner.invoke(
+            cli.zipzarr,
+            [str(src), str(zip_path), "--force", "-k"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert zip_path.read_bytes() != b"existing"
+        assert src.exists()
+
+    def test_unzip_force_overwrites_dir(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        zip_path = tmp_path / "store.zip"
+        out = tmp_path / "store-out.zarr"
+        _make_sample_zarr(src)
+        out.mkdir()
+        (out / "stale").write_text("stale")
+
+        runner = ct.CliRunner()
+        runner.invoke(cli.zipzarr, [str(src), str(zip_path), "-k"])
+        result = runner.invoke(
+            cli.zipzarr,
+            ["-u", "-k", str(zip_path), str(out), "--force"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert not (out / "stale").exists()
+
+    @pytest.mark.parametrize("flag", ["-P", "-Q"])
+    def test_progress_flag(self, tmp_path, flag):
+        src = tmp_path / "store.zarr"
+        zip_path = tmp_path / "store.zip"
+        _make_sample_zarr(src)
+        runner = ct.CliRunner()
+        result = runner.invoke(
+            cli.zipzarr,
+            [str(src), str(zip_path), flag, "-k"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert zip_path.exists()
+
+    def test_zip_default_dest_appends_zip(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        _make_sample_zarr(src)
+        runner = ct.CliRunner()
+        result = runner.invoke(cli.zipzarr, [str(src), "-k"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert (tmp_path / "store.zarr.zip").exists()
+
+    def test_zip_default_deletes_source(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        _make_sample_zarr(src)
+        runner = ct.CliRunner()
+        result = runner.invoke(cli.zipzarr, [str(src)], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert not src.exists()
+        assert (tmp_path / "store.zarr.zip").exists()
+
+    def test_zip_keep_preserves_source(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        _make_sample_zarr(src)
+        runner = ct.CliRunner()
+        result = runner.invoke(cli.zipzarr, [str(src), "-k"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert src.exists()
+        assert (tmp_path / "store.zarr.zip").exists()
+
+    def test_unzip_default_dest_strips_zip(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        zip_path = tmp_path / "store.zarr.zip"
+        _make_sample_zarr(src)
+        runner = ct.CliRunner()
+        runner.invoke(cli.zipzarr, [str(src), str(zip_path), "--force"])  # deletes src
+        assert not src.exists()
+        assert zip_path.exists()
+
+        result = runner.invoke(
+            cli.zipzarr, ["-u", str(zip_path)], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+        assert not zip_path.exists()
+        root = zarr.open(store=src, mode="r")
+        assert root.attrs["test_attr"] == "hello"
+        np.testing.assert_array_equal(root["data"][:], [1, 2, 3])
+
+    def test_unzip_keep_preserves_zip(self, tmp_path):
+        src = tmp_path / "store.zarr"
+        zip_path = tmp_path / "store.zarr.zip"
+        _make_sample_zarr(src)
+        runner = ct.CliRunner()
+        runner.invoke(cli.zipzarr, [str(src), str(zip_path), "-k"])
+        assert zip_path.exists()
+        shutil.rmtree(src)
+
+        result = runner.invoke(
+            cli.zipzarr, ["-u", "-k", str(zip_path)], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+        assert zip_path.exists()
+        assert src.exists()
+
+    def test_unzip_default_dest_requires_zip_suffix(self, tmp_path):
+        bin_path = tmp_path / "store.bin"
+        bin_path.write_bytes(b"not a zip")
+        runner = ct.CliRunner()
+        result = runner.invoke(cli.zipzarr, ["-u", str(bin_path)])
+        assert result.exit_code != 0
+        assert "does not end in .zip" in result.stderr
+        assert bin_path.exists()

--- a/tests/test_zarr_utils.py
+++ b/tests/test_zarr_utils.py
@@ -50,6 +50,52 @@ class TestZipZarr:
             for info in zf.infolist():
                 assert info.compress_type == zipfile.ZIP_STORED
 
+    @pytest.mark.parametrize("show_progress", [True, False])
+    def test_show_progress(self, tmp_path, show_progress):
+        dir_path = tmp_path / "store"
+        zip_path = tmp_path / "store.zip"
+        _create_test_zarr(dir_path)
+        zarr_utils.zip_zarr(dir_path, zip_path, show_progress=show_progress)
+        assert zip_path.exists()
+
+
+class TestUnzipZarr:
+    def test_roundtrip(self, tmp_path):
+        dir_path = tmp_path / "store"
+        zip_path = tmp_path / "store.zip"
+        out_path = tmp_path / "store-out"
+        _create_test_zarr(dir_path)
+        zarr_utils.zip_zarr(dir_path, zip_path)
+        zarr_utils.unzip_zarr(zip_path, out_path)
+        root = zarr.open(store=out_path, mode="r")
+        assert root.attrs["test_attr"] == "hello"
+        nt.assert_array_equal(root["data"][:], [1, 2, 3])
+
+    def test_matches_source_tree(self, tmp_path):
+        dir_path = tmp_path / "store"
+        zip_path = tmp_path / "store.zip"
+        out_path = tmp_path / "store-out"
+        _create_test_zarr(dir_path)
+        zarr_utils.zip_zarr(dir_path, zip_path)
+        zarr_utils.unzip_zarr(zip_path, out_path)
+        src_files = sorted(
+            p.relative_to(dir_path) for p in dir_path.rglob("*") if p.is_file()
+        )
+        out_files = sorted(
+            p.relative_to(out_path) for p in out_path.rglob("*") if p.is_file()
+        )
+        assert src_files == out_files
+
+    @pytest.mark.parametrize("show_progress", [True, False])
+    def test_show_progress(self, tmp_path, show_progress):
+        dir_path = tmp_path / "store"
+        zip_path = tmp_path / "store.zip"
+        out_path = tmp_path / "store-out"
+        _create_test_zarr(dir_path)
+        zarr_utils.zip_zarr(dir_path, zip_path)
+        zarr_utils.unzip_zarr(zip_path, out_path, show_progress=show_progress)
+        assert out_path.exists()
+
 
 class TestDirToMemoryStore:
     def test_copies_data(self, tmp_path):


### PR DESCRIPTION
Closes #466

New top-level command that wraps zip_zarr/unzip_zarr, with gzip-like defaults: optional DEST derived from SRC, source removed on success unless -k/--keep is passed, and -u/--unzip to reverse direction.

Log the operation (zip/unzip SRC -> DEST) and source removal in the CLI, and file counts in zip_zarr/unzip_zarr. Visible at -v (INFO).