### PR TITLE
Drop dimension_separator from the vcf encode API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
   filesystem inode overhead; they now report the compressed bytes as
   returned by Zarr's ``Array.nbytes_stored()`` (#471).
 
+- Change the metadata format for distributed encode to drop the
+  unused ``dimension_separator`` field. The metadata
+  format version has been bumped from ``0.1`` to ``0.2``: any
+  in-progress distributed ``dencode`` run started with an earlier
+  version will now fail with a format-version-mismatch error at
+  ``dencode-partition``/``dencode-finalise`` time and must be
+  restarted from ``dencode-init``. (#472)
+
 *Bug fixes*
 
 - Fix stdlib ``typing`` module shadowing caused by ``bio2zarr/typing.py``,

--- a/bio2zarr/vcf.py
+++ b/bio2zarr/vcf.py
@@ -1738,7 +1738,6 @@ def encode(
     variants_chunk_size=None,
     samples_chunk_size=None,
     max_variant_chunks=None,
-    dimension_separator=None,
     max_memory=None,
     local_alleles=None,
     ploidy=None,
@@ -1759,7 +1758,6 @@ def encode(
             local_alleles=local_alleles,
             ploidy=ploidy,
             max_variant_chunks=max_variant_chunks,
-            dimension_separator=dimension_separator,
         )
         vzw = vcz.VcfZarrWriter(IntermediateColumnarFormat, zr.dir)
         vzw.encode_all_partitions(
@@ -1783,7 +1781,6 @@ def encode_init(
     local_alleles=None,
     ploidy=None,
     max_variant_chunks=None,
-    dimension_separator=None,
     max_memory=None,
     worker_processes=core.DEFAULT_WORKER_PROCESSES,
     show_progress=False,
@@ -1810,7 +1807,6 @@ def encode_init(
         icf_store,
         target_num_partitions=target_num_partitions,
         schema=schema_instance,
-        dimension_separator=dimension_separator,
         max_variant_chunks=max_variant_chunks,
     )
 

--- a/bio2zarr/vcz.py
+++ b/bio2zarr/vcz.py
@@ -492,7 +492,7 @@ class VcfZarrPartition:
         return partitions
 
 
-VZW_METADATA_FORMAT_VERSION = "0.1"
+VZW_METADATA_FORMAT_VERSION = "0.2"
 
 
 @dataclasses.dataclass
@@ -500,7 +500,6 @@ class VcfZarrWriterMetadata(core.JsonDataclass):
     format_version: str
     source_path: str
     schema: VcfZarrSchema
-    dimension_separator: str
     partitions: list
     provenance: dict
 
@@ -656,7 +655,6 @@ class VcfZarrWriter:
         *,
         target_num_partitions,
         schema,
-        dimension_separator=None,
         max_variant_chunks=None,
     ):
         self.source = source
@@ -669,16 +667,10 @@ class VcfZarrWriter:
             target_num_partitions,
             max_chunks=max_variant_chunks,
         )
-        # Default to using nested directories following the Zarr v3 default.
-        # This seems to require version 2.17+ to work properly
-        dimension_separator = (
-            "/" if dimension_separator is None else dimension_separator
-        )
         self.metadata = VcfZarrWriterMetadata(
             format_version=VZW_METADATA_FORMAT_VERSION,
             source_path=str(self.source.path),
             schema=schema,
-            dimension_separator=dimension_separator,
             partitions=partitions,
             # Bare minimum here for provenance - see comments above
             provenance={"source": f"bio2zarr-{provenance.__version__}"},

--- a/bio2zarr/zarr_utils.py
+++ b/bio2zarr/zarr_utils.py
@@ -225,9 +225,6 @@ def move_chunks(src_path, dest_path, partition, name):
             chunk_files = [
                 path for path in src_chunks.iterdir() if not path.name.startswith(".")
             ]
-    # TODO check for a count of then number of files. If we require a
-    # dimension_separator of "/" then we could make stronger assertions
-    # here, as we'd always have num_variant_chunks
     logger.debug(f"Moving {len(chunk_files)} chunks for {name} partition {partition}")
     for chunk_file in chunk_files:
         os.rename(chunk_file, dest / chunk_file.name)


### PR DESCRIPTION
Closes #446

The option was a leftover from Zarr-python v2 and had no effect under v3 — the value was stored in the writer metadata but never read back. Bump VZW_METADATA_FORMAT_VERSION to 0.2 so any in-progress dencode run fails cleanly instead of with a TypeError on the removed field.