### PR TITLE
Support f2 and f8 float dtypes for INFO and FORMAT fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ In development.
 
 *New features*
 
+- Support ``f2`` (16-bit) and ``f8`` (64-bit) float dtypes for INFO and FORMAT
+  fields by editing the ``dtype`` in a storage schema. Missing and fill
+  sentinels are now defined per float dtype.
+
 - Add ``vcf2zarr create-index`` which builds a region index on a local VCZ store (#490).
   
 # 0.2.0 2026-04-15

--- a/bio2zarr/constants.py
+++ b/bio2zarr/constants.py
@@ -5,12 +5,29 @@ INT_FILL = -2
 STR_MISSING = "."
 STR_FILL = ""
 
+# Floats use two signalling NaN bit patterns to distinguish a missing value
+# (a "." in the VCF) from fill (padding / vector-end in a ragged row). The
+# float32 patterns mirror htslib's bcf_float_missing / bcf_float_vector_end. The
+# float16 and float64 patterns follow the same convention (exponent all ones,
+# mantissa low bits 1 and 2) but are a bio2zarr extension: the VCF Zarr spec only
+# defines the float32 patterns, so any reader (e.g. vcztools, sgkit) must adopt
+# these same f2/f8 patterns to interpret f2/f8 fields.
 FLOAT32_MISSING, FLOAT32_FILL = np.array([0x7F800001, 0x7F800002], dtype=np.int32).view(
     np.float32
 )
-FLOAT32_MISSING_AS_INT32, FLOAT32_FILL_AS_INT32 = np.array(
-    [0x7F800001, 0x7F800002], dtype=np.int32
+FLOAT16_MISSING, FLOAT16_FILL = np.array([0x7C01, 0x7C02], dtype=np.int16).view(
+    np.float16
 )
+FLOAT64_MISSING, FLOAT64_FILL = np.array(
+    [0x7FF0000000000001, 0x7FF0000000000002], dtype=np.uint64
+).view(np.float64)
+
+# Maps a float dtype to its (missing, fill) sentinel pair.
+FLOAT_MISSING_FILL = {
+    np.dtype("float16"): (FLOAT16_MISSING, FLOAT16_FILL),
+    np.dtype("float32"): (FLOAT32_MISSING, FLOAT32_FILL),
+    np.dtype("float64"): (FLOAT64_MISSING, FLOAT64_FILL),
+}
 
 
 MIN_INT_VALUE = np.iinfo(np.int32).min + 2

--- a/bio2zarr/constants.py
+++ b/bio2zarr/constants.py
@@ -5,13 +5,6 @@ INT_FILL = -2
 STR_MISSING = "."
 STR_FILL = ""
 
-# Floats use two signalling NaN bit patterns to distinguish a missing value
-# (a "." in the VCF) from fill (padding / vector-end in a ragged row). The
-# float32 patterns mirror htslib's bcf_float_missing / bcf_float_vector_end. The
-# float16 and float64 patterns follow the same convention (exponent all ones,
-# mantissa low bits 1 and 2) but are a bio2zarr extension: the VCF Zarr spec only
-# defines the float32 patterns, so any reader (e.g. vcztools, sgkit) must adopt
-# these same f2/f8 patterns to interpret f2/f8 fields.
 FLOAT32_MISSING, FLOAT32_FILL = np.array([0x7F800001, 0x7F800002], dtype=np.int32).view(
     np.float32
 )

--- a/bio2zarr/plink.py
+++ b/bio2zarr/plink.py
@@ -185,7 +185,7 @@ class PlinkFormat(vcz.Source):
         for chrom in self.bim.contig[start:stop]:
             yield chrom_to_contig_index[str(chrom)]
 
-    def iter_field(self, field_name, shape, start, stop):
+    def iter_field(self, field_name, shape, dtype, start, stop):
         assert field_name == "position"  # Only position field is supported from plink
         yield from self.bim.position[start:stop]
 

--- a/bio2zarr/tskit.py
+++ b/bio2zarr/tskit.py
@@ -94,7 +94,7 @@ class TskitFormat(vcz.Source):
     def iter_contig(self, start, stop):
         yield from (0 for _ in range(start, stop))
 
-    def iter_field(self, field_name, shape, start, stop):
+    def iter_field(self, field_name, shape, dtype, start, stop):
         if field_name == "position":
             for pos in self.vcf_positions[start:stop]:
                 yield int(pos)

--- a/bio2zarr/vcf.py
+++ b/bio2zarr/vcf.py
@@ -375,11 +375,11 @@ def sanitise_value_bool(shape, value):
     return x
 
 
-def sanitise_value_float_scalar(shape, value):
-    x = value
+def sanitise_value_float_scalar(dtype, shape, value):
     if value is None:
-        x = [constants.FLOAT32_MISSING]
-    return x[0]
+        missing, _ = constants.FLOAT_MISSING_FILL[np.dtype(dtype)]
+        return missing
+    return value[0]
 
 
 def sanitise_value_int_scalar(shape, value):
@@ -429,26 +429,32 @@ def drop_empty_second_dim(value):
     return value
 
 
-def sanitise_value_float_1d(shape, value):
+def sanitise_value_float_1d(dtype, shape, value):
+    missing, fill = constants.FLOAT_MISSING_FILL[np.dtype(dtype)]
     if value is None:
-        return np.full(shape, constants.FLOAT32_MISSING)
+        return np.full(shape, missing, dtype=dtype)
     else:
-        value = np.array(value, ndmin=1, dtype=np.float32, copy=True)
+        value = np.array(value, ndmin=1, dtype=dtype, copy=True)
         # numpy will map None values to Nan, but we need a
         # specific NaN
-        value[np.isnan(value)] = constants.FLOAT32_MISSING
+        value[np.isnan(value)] = missing
         value = drop_empty_second_dim(value)
-        result = np.full(shape, constants.FLOAT32_FILL, dtype=np.float32)
+        result = np.full(shape, fill, dtype=dtype)
         result[: value.shape[0]] = value
         return result
 
 
-def sanitise_value_float_2d(shape, value):
+def sanitise_value_float_2d(dtype, shape, value):
+    missing, fill = constants.FLOAT_MISSING_FILL[np.dtype(dtype)]
     if value is None:
-        return np.full(shape, constants.FLOAT32_MISSING)
+        return np.full(shape, missing, dtype=dtype)
     else:
-        value = np.array(value, ndmin=2, dtype=np.float32, copy=True)
-        result = np.full(shape, constants.FLOAT32_FILL, dtype=np.float32)
+        value = np.array(value, ndmin=2, dtype=dtype, copy=True)
+        # A missing value is stored as a NaN; re-stamp it as the canonical
+        # missing sentinel for this dtype, as casting between float dtypes does
+        # not preserve the NaN bit pattern.
+        value[np.isnan(value)] = missing
+        result = np.full(shape, fill, dtype=dtype)
         result[:, : value.shape[1]] = value
         return result
 
@@ -723,18 +729,18 @@ class IntermediateColumnarFormatField:
         assert j == self.num_records
         return ret
 
-    def sanitiser_factory(self, shape):
+    def sanitiser_factory(self, shape, dtype):
         assert len(shape) <= 2
         if self.vcf_field.vcf_type == "Flag":
             assert len(shape) == 0
             return partial(sanitise_value_bool, shape)
         elif self.vcf_field.vcf_type == "Float":
             if len(shape) == 0:
-                return partial(sanitise_value_float_scalar, shape)
+                return partial(sanitise_value_float_scalar, dtype, shape)
             elif len(shape) == 1:
-                return partial(sanitise_value_float_1d, shape)
+                return partial(sanitise_value_float_1d, dtype, shape)
             else:
-                return partial(sanitise_value_float_2d, shape)
+                return partial(sanitise_value_float_2d, dtype, shape)
         elif self.vcf_field.vcf_type == "Integer":
             if len(shape) == 0:
                 return partial(sanitise_value_int_scalar, shape)
@@ -1050,9 +1056,9 @@ class IntermediateColumnarFormat(vcz.Source):
             # here, please do open an issue with a reproducible example!
             yield lookup[value[0]]
 
-    def iter_field(self, field_name, shape, start, stop):
+    def iter_field(self, field_name, shape, dtype, start, stop):
         source_field = self.fields[field_name]
-        sanitiser = source_field.sanitiser_factory(shape)
+        sanitiser = source_field.sanitiser_factory(shape, dtype)
         for value in source_field.iter_values(start, stop):
             yield sanitiser(value)
 

--- a/bio2zarr/vcz.py
+++ b/bio2zarr/vcz.py
@@ -85,7 +85,7 @@ class Source(abc.ABC):
         return
 
     @abc.abstractmethod
-    def iter_field(self, field_name, shape, start, stop):
+    def iter_field(self, field_name, shape, dtype, start, stop):
         pass
 
     @abc.abstractmethod
@@ -344,6 +344,18 @@ class VcfZarrSchema(core.JsonDataclass):
                         f"Dimension '{dim}' used in field '{field.name}' is "
                         "not defined in the schema"
                     )
+
+            try:
+                dtype = np.dtype(field.dtype)
+            except TypeError:
+                raise ValueError(
+                    f"Field '{field.name}' has invalid dtype '{field.dtype}'"
+                ) from None
+            if dtype.kind == "f" and dtype not in constants.FLOAT_MISSING_FILL:
+                raise ValueError(
+                    f"Field '{field.name}' has unsupported float dtype "
+                    f"'{field.dtype}'; use one of f2, f4 or f8"
+                )
 
             chunk_nbytes = field.get_chunk_nbytes(self)
             # This is the Blosc max buffer size
@@ -899,6 +911,7 @@ class VcfZarrWriter:
         for value in self.source.iter_field(
             array_spec.source,
             ba.buff.shape[1:],
+            ba.buff.dtype,
             partition.start,
             partition.stop,
         ):

--- a/bio2zarr/vcz.py
+++ b/bio2zarr/vcz.py
@@ -19,6 +19,23 @@ ZARR_SCHEMA_FORMAT_VERSION = "0.6"
 DEFAULT_VARIANT_CHUNK_SIZE = 1000
 DEFAULT_SAMPLE_CHUNK_SIZE = 10_000
 
+# The dtypes (and widths) that fields are permitted to use. Signed integers
+# of width 1, 2, 4 and 8 bytes, the three supported float widths, booleans,
+# single-character strings (VCF Character fields) and the variable-length
+# string dtype.
+SUPPORTED_DTYPES = {
+    np.dtype("i1"),
+    np.dtype("i2"),
+    np.dtype("i4"),
+    np.dtype("i8"),
+    np.dtype("f2"),
+    np.dtype("f4"),
+    np.dtype("f8"),
+    np.dtype("bool"),
+    np.dtype("U1"),
+    np.dtype(zarr_utils.STRING_DTYPE_NAME),
+}
+
 _fixed_field_descriptions = {
     "variant_contig": "An identifier from the reference genome or an angle-bracketed ID"
     " string pointing to a contig in the assembly file",
@@ -355,6 +372,10 @@ class VcfZarrSchema(core.JsonDataclass):
                 raise ValueError(
                     f"Field '{field.name}' has unsupported float dtype "
                     f"'{field.dtype}'; use one of f2, f4 or f8"
+                )
+            if dtype not in SUPPORTED_DTYPES:
+                raise ValueError(
+                    f"Field '{field.name}' has unsupported dtype '{field.dtype}'"
                 )
 
             chunk_nbytes = field.get_chunk_nbytes(self)

--- a/bio2zarr/vcz.py
+++ b/bio2zarr/vcz.py
@@ -720,7 +720,7 @@ class VcfZarrWriter:
         root = zarr_utils.open_zarr_append(self.path, zarr_format=self.zarr_format)
         root.attrs.update(
             {
-                "vcf_zarr_version": "0.4",
+                "vcf_zarr_version": "0.5",
                 "source": f"bio2zarr-{provenance.__version__}",
             }
         )

--- a/bio2zarr/vcz_verification.py
+++ b/bio2zarr/vcz_verification.py
@@ -9,14 +9,44 @@ from bio2zarr.zarr_utils import first_dim_iter
 from . import constants
 
 
+def float_int_view(a):
+    """
+    Views a float value or array as integers of the same width, so that
+    sentinel NaN bit patterns can be compared exactly.
+    """
+    a = np.asarray(a)
+    int_dtype = np.dtype(f"i{a.dtype.itemsize}")
+    return a.view(int_dtype)
+
+
 def assert_all_missing_float(a):
-    v = np.array(a, dtype=np.float32).view(np.int32)
-    nt.assert_equal(v, constants.FLOAT32_MISSING_AS_INT32)
+    a = np.asarray(a)
+    missing, _ = constants.FLOAT_MISSING_FILL[a.dtype]
+    nt.assert_equal(float_int_view(a), float_int_view(missing))
 
 
 def assert_all_fill_float(a):
-    v = np.array(a, dtype=np.float32).view(np.int32)
-    nt.assert_equal(v, constants.FLOAT32_FILL_AS_INT32)
+    a = np.asarray(a)
+    _, fill = constants.FLOAT_MISSING_FILL[a.dtype]
+    nt.assert_equal(float_int_view(a), float_int_view(fill))
+
+
+def expected_float_array(vcf_val, dtype):
+    """
+    Converts a cyvcf2 float32 array, which uses the float32 missing and fill
+    sentinels, into the array expected in the Zarr store for the given float
+    dtype, re-stamping the sentinels for that dtype.
+    """
+    dtype = np.dtype(dtype)
+    missing, fill = constants.FLOAT_MISSING_FILL[dtype]
+    source = np.asarray(vcf_val, dtype=np.float32)
+    source_as_int = source.view(np.int32)
+    is_missing = source_as_int == float_int_view(constants.FLOAT32_MISSING)
+    is_fill = source_as_int == float_int_view(constants.FLOAT32_FILL)
+    result = source.astype(dtype)
+    result[is_missing] = missing
+    result[is_fill] = fill
+    return result
 
 
 def assert_all_missing_int(a):
@@ -95,6 +125,10 @@ def assert_info_val_equal(vcf_val, zarr_val, vcf_type):
         v = [vcf_missing_value_map[vcf_type] if x is None else x for x in vcf_val]
         missing = np.array([j for j, x in enumerate(vcf_val) if x is None], dtype=int)
         a = np.array(v)
+        if vcf_type == "Float":
+            # Round to the stored dtype so a lossy f2 round-trip compares equal;
+            # the missing positions are checked exactly below.
+            a = a.astype(zarr_val.dtype)
         k = len(a)
         # We are checking for int missing twice here, but it's necessary to have
         # a separate check for floats because different NaNs compare equal
@@ -106,7 +140,10 @@ def assert_info_val_equal(vcf_val, zarr_val, vcf_type):
         # Scalar
         zarr_val = np.array(zarr_val, ndmin=1)
         assert len(zarr_val.shape) == 1
-        assert vcf_val == zarr_val[0]
+        if vcf_type == "Float":
+            nt.assert_equal(np.asarray(vcf_val, dtype=zarr_val.dtype), zarr_val[0])
+        else:
+            assert vcf_val == zarr_val[0]
         if len(zarr_val) > 1:
             assert_all_fill(zarr_val[1:], vcf_type)
 
@@ -137,11 +174,13 @@ def assert_format_val_equal(vcf_val, zarr_val, vcf_type, vcf_number):
                 assert_all_fill(zarr_val[:, k:], vcf_type)
                 zarr_val = zarr_val[:, :k]
         assert vcf_val.shape == zarr_val.shape
+        if vcf_type == "Float":
+            expected = expected_float_array(vcf_val, zarr_val.dtype)
+            nt.assert_equal(float_int_view(expected), float_int_view(zarr_val))
+            return
         if vcf_type == "Integer":
             vcf_val[vcf_val == constants.VCF_INT_MISSING] = constants.INT_MISSING
             vcf_val[vcf_val == constants.VCF_INT_FILL] = constants.INT_FILL
-        elif vcf_type == "Float":
-            nt.assert_equal(vcf_val.view(np.int32), zarr_val.view(np.int32))
 
         nt.assert_equal(vcf_val, zarr_val)
 

--- a/docs/vcf2zarr/tutorial.md
+++ b/docs/vcf2zarr/tutorial.md
@@ -156,6 +156,11 @@ Better mechanisms for updating schemas via a Python API would be
 a useful addition here.
 :::
 
+The ``dtype`` of a field can also be edited. Float fields default to ``f4``
+(32-bit, matching the VCF source) and may be set to ``f2`` (16-bit) to save
+space or ``f8`` (64-bit). Note that ``f2`` is lossy: precision is reduced and
+values larger than about 65504 overflow to infinity. ``f8`` adds no precision
+over the ``f4`` source.
 
 A common thing we might want to do is to drop some fields entirely
 from the final Zarr, either because they are too big and unwieldy 

--- a/tests/test_tskit.py
+++ b/tests/test_tskit.py
@@ -333,12 +333,12 @@ class TestTskitFormat:
 
     def test_iter_field(self, fx_simple_ts):
         format_obj = tsk.TskitFormat(fx_simple_ts)
-        positions = list(format_obj.iter_field("position", None, 0, 3))
+        positions = list(format_obj.iter_field("position", None, None, 0, 3))
         assert positions == [10, 20, 30]
-        positions = list(format_obj.iter_field("position", None, 1, 3))
+        positions = list(format_obj.iter_field("position", None, None, 1, 3))
         assert positions == [20, 30]
         with pytest.raises(ValueError, match="Unknown field"):
-            list(format_obj.iter_field("unknown_field", None, 0, 3))
+            list(format_obj.iter_field("unknown_field", None, None, 0, 3))
 
     def test_zero_samples(self, fx_simple_ts):
         model_mapping = tskit_model_mapping(fx_simple_ts, np.array([]))

--- a/tests/test_tskit.py
+++ b/tests/test_tskit.py
@@ -254,6 +254,24 @@ class TestTskitFormat:
         )
         assert position_field.dtype == "i8"
 
+    def test_large_position_round_trip(self):
+        # A position beyond the int32 range must survive encoding as i8
+        # without truncation.
+        big_position = np.iinfo(np.int32).max + 1
+        tables = tskit.TableCollection(sequence_length=3_000_000_000)
+        tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, time=0)
+        tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, time=0)
+        tables.sites.add_row(position=10, ancestral_state="A")
+        tables.sites.add_row(position=big_position, ancestral_state="C")
+        tables.mutations.add_row(site=0, node=0, derived_state="T")
+        tables.mutations.add_row(site=1, node=0, derived_state="G")
+        ts = tables.tree_sequence()
+
+        root = tsk.convert(ts, worker_processes=0)
+        position = root["variant_position"]
+        assert position.dtype == np.dtype("i8")
+        nt.assert_array_equal(position[:], [10, big_position])
+
     def test_initialization_defaults(self, fx_simple_ts):
         format_obj = tsk.TskitFormat(fx_simple_ts)
         assert format_obj.path is None

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -1195,18 +1195,23 @@ class TestFloatFieldDtypes:
         zarr_path = self.encode(tmp_path, dtype)
         vcz_verification.verify(self.data_path, zarr_path)
 
-    def test_f2_sentinels_preserved(self, tmp_path):
-        zarr_path = self.encode(tmp_path, "f2")
+    @pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+    def test_sentinels_preserved(self, tmp_path, dtype):
+        zarr_path = self.encode(tmp_path, dtype)
         root = zarr.open(zarr_path, mode="r")
-        missing = int(constants.FLOAT16_MISSING.view(np.int16))
-        fill = int(constants.FLOAT16_FILL.view(np.int16))
+        float_dtype = np.dtype(dtype)
+        int_dtype = np.dtype(f"i{float_dtype.itemsize}")
+        missing_value, fill_value = constants.FLOAT_MISSING_FILL[float_dtype]
+        missing = int(missing_value.view(int_dtype))
+        fill = int(fill_value.view(int_dtype))
         seen = set()
         for name in self.float_arrays:
             values = root[name][:]
-            nan_as_int = values.view(np.int16)[np.isnan(values)]
+            nan_as_int = values.view(int_dtype)[np.isnan(values)]
             seen.update(int(x) for x in np.unique(nan_as_int))
-        # Every NaN in an f2 array must be exactly the missing or fill sentinel;
-        # a naive f4->f2 cast would collapse both into one indistinguishable NaN.
+        # Every NaN in a float array must be exactly the missing or fill
+        # sentinel; a naive cast between float widths would collapse both into
+        # one indistinguishable NaN.
         assert seen == {missing, fill}
 
 

--- a/tests/test_vcf_examples.py
+++ b/tests/test_vcf_examples.py
@@ -11,7 +11,7 @@ import pytest
 import xarray.testing as xt
 import zarr
 
-from bio2zarr import constants, provenance, vcz_verification
+from bio2zarr import constants, provenance, vcz, vcz_verification
 from bio2zarr import vcf as vcf_mod
 from tests.utils import load_dataset
 
@@ -1119,6 +1119,95 @@ class TestGeneratedFieldsExample:
     #     non_missing = [v for v in pcvcf["FORMAT/FS2"].values if v is not None]
     #     nt.assert_array_equal(non_missing[0], [["bc", "op"], [".", "op"]])
     #     nt.assert_array_equal(non_missing[1], [["bc", "."], [".", "."]])
+
+
+class TestFloatSentinels:
+    @pytest.mark.parametrize(
+        ("missing", "fill"),
+        [
+            (constants.FLOAT16_MISSING, constants.FLOAT16_FILL),
+            (constants.FLOAT32_MISSING, constants.FLOAT32_FILL),
+            (constants.FLOAT64_MISSING, constants.FLOAT64_FILL),
+        ],
+    )
+    def test_distinct_nan(self, missing, fill):
+        assert np.isnan(missing)
+        assert np.isnan(fill)
+        int_dtype = np.dtype(f"i{missing.dtype.itemsize}")
+        assert missing.view(int_dtype) != fill.view(int_dtype)
+
+    def test_lookup_dtypes(self):
+        for dtype, (missing, fill) in constants.FLOAT_MISSING_FILL.items():
+            assert missing.dtype == dtype
+            assert fill.dtype == dtype
+
+
+class TestFloatFieldDtypes:
+    # field_type_combos has Float INFO and FORMAT fields with Number=1,2,A,R,G,.
+    # covering scalar, fixed-length and ragged cases with missing values.
+    data_path = "tests/data/vcf/field_type_combos.vcf.gz"
+
+    float_arrays = [
+        "variant_IF1",
+        "variant_IF2",
+        "variant_IFA",
+        "variant_IFR",
+        "variant_IFD",
+        "call_FF1",
+        "call_FF2",
+        "call_FFA",
+        "call_FFR",
+        "call_FFG",
+        "call_FFD",
+    ]
+
+    def encode(self, tmp_path, dtype):
+        icf_path = tmp_path / "icf"
+        vcf_mod.explode(icf_path, [self.data_path], worker_processes=0)
+        schema_path = tmp_path / "schema.json"
+        with open(schema_path, "w") as f:
+            vcf_mod.mkschema(icf_path, f)
+        schema = vcz.VcfZarrSchema.fromjson(schema_path.read_text())
+        float_fields = [
+            field
+            for field in schema.fields
+            if field.source is not None and np.dtype(field.dtype).kind == "f"
+        ]
+        for field in float_fields:
+            # Float fields default to f4; there is no automatic selection of a
+            # smaller or larger float dtype.
+            assert field.dtype == "f4"
+            field.dtype = dtype
+        schema_path.write_text(schema.asjson())
+        zarr_path = tmp_path / "test.zarr"
+        vcf_mod.encode(icf_path, zarr_path, schema_path=schema_path, worker_processes=0)
+        return zarr_path
+
+    @pytest.mark.parametrize("dtype", ["f2", "f8"])
+    def test_array_dtype(self, tmp_path, dtype):
+        zarr_path = self.encode(tmp_path, dtype)
+        root = zarr.open(zarr_path, mode="r")
+        for name in self.float_arrays:
+            assert root[name].dtype == np.dtype(dtype)
+
+    @pytest.mark.parametrize("dtype", ["f2", "f8"])
+    def test_round_trip(self, tmp_path, dtype):
+        zarr_path = self.encode(tmp_path, dtype)
+        vcz_verification.verify(self.data_path, zarr_path)
+
+    def test_f2_sentinels_preserved(self, tmp_path):
+        zarr_path = self.encode(tmp_path, "f2")
+        root = zarr.open(zarr_path, mode="r")
+        missing = int(constants.FLOAT16_MISSING.view(np.int16))
+        fill = int(constants.FLOAT16_FILL.view(np.int16))
+        seen = set()
+        for name in self.float_arrays:
+            values = root[name][:]
+            nan_as_int = values.view(np.int16)[np.isnan(values)]
+            seen.update(int(x) for x in np.unique(nan_as_int))
+        # Every NaN in an f2 array must be exactly the missing or fill sentinel;
+        # a naive f4->f2 cast would collapse both into one indistinguishable NaN.
+        assert seen == {missing, fill}
 
 
 class TestSplitFileErrors:

--- a/tests/test_vcz.py
+++ b/tests/test_vcz.py
@@ -323,6 +323,54 @@ class TestValidateSchema:
         with pytest.raises(ValueError, match="unsupported float dtype"):
             schema.validate()
 
+    @pytest.mark.parametrize(
+        "dtype", ["i1", "i2", "i4", "i8", "f2", "f4", "f8", "bool", "U1", "T"]
+    )
+    def test_valid_dtype(self, schema, dtype):
+        schema = vcz.VcfZarrSchema.fromdict(schema.asdict())
+        field = schema.field_map()["variant_H2"]
+        schema.fields = [field]
+        field.dtype = dtype
+        schema.validate()
+
+    @pytest.mark.parametrize("dtype", ["u1", "u2", "u4", "u8"])
+    def test_unsupported_unsigned_int_dtype(self, schema, dtype):
+        schema = vcz.VcfZarrSchema.fromdict(schema.asdict())
+        field = schema.field_map()["variant_H2"]
+        schema.fields = [field]
+        field.dtype = dtype
+        with pytest.raises(ValueError, match="unsupported dtype"):
+            schema.validate()
+
+    @pytest.mark.parametrize("dtype", ["i16", "int128"])
+    def test_unsupported_int_width(self, schema, dtype):
+        # numpy has no integer wider than 8 bytes, so these resolve to
+        # invalid rather than unsupported dtypes.
+        schema = vcz.VcfZarrSchema.fromdict(schema.asdict())
+        field = schema.field_map()["variant_H2"]
+        schema.fields = [field]
+        field.dtype = dtype
+        with pytest.raises(ValueError, match="invalid dtype"):
+            schema.validate()
+
+    @pytest.mark.parametrize("dtype", ["U2", "U5", "U10", "S1", "S4"])
+    def test_unsupported_string_dtype(self, schema, dtype):
+        schema = vcz.VcfZarrSchema.fromdict(schema.asdict())
+        field = schema.field_map()["variant_H2"]
+        schema.fields = [field]
+        field.dtype = dtype
+        with pytest.raises(ValueError, match="unsupported dtype"):
+            schema.validate()
+
+    @pytest.mark.parametrize("dtype", ["complex64", "complex128", "datetime64[s]"])
+    def test_unsupported_dtype(self, schema, dtype):
+        schema = vcz.VcfZarrSchema.fromdict(schema.asdict())
+        field = schema.field_map()["variant_H2"]
+        schema.fields = [field]
+        field.dtype = dtype
+        with pytest.raises(ValueError, match="unsupported dtype"):
+            schema.validate()
+
     @pytest.mark.parametrize("size", [2**31 - 1, 2**30])
     def test_chunk_not_too_large(self, schema, size):
         schema = vcz.VcfZarrSchema.fromdict(schema.asdict())

--- a/tests/test_vcz.py
+++ b/tests/test_vcz.py
@@ -296,6 +296,33 @@ class TestValidateSchema:
         with pytest.raises(ValueError, match="Field variant_H2 chunks are too large"):
             schema.validate()
 
+    @pytest.mark.parametrize("dtype", ["f2", "f4", "f8"])
+    def test_valid_float_dtype(self, schema, dtype):
+        schema = vcz.VcfZarrSchema.fromdict(schema.asdict())
+        field = schema.field_map()["variant_H2"]
+        schema.fields = [field]
+        field.dtype = dtype
+        schema.validate()
+
+    def test_invalid_dtype(self, schema):
+        schema = vcz.VcfZarrSchema.fromdict(schema.asdict())
+        field = schema.field_map()["variant_H2"]
+        schema.fields = [field]
+        field.dtype = "f3"
+        with pytest.raises(ValueError, match="invalid dtype"):
+            schema.validate()
+
+    @pytest.mark.skipif(
+        not hasattr(np, "float128"), reason="float128 not available on this platform"
+    )
+    def test_unsupported_float_dtype(self, schema):
+        schema = vcz.VcfZarrSchema.fromdict(schema.asdict())
+        field = schema.field_map()["variant_H2"]
+        schema.fields = [field]
+        field.dtype = "float128"
+        with pytest.raises(ValueError, match="unsupported float dtype"):
+            schema.validate()
+
     @pytest.mark.parametrize("size", [2**31 - 1, 2**30])
     def test_chunk_not_too_large(self, schema, size):
         schema = vcz.VcfZarrSchema.fromdict(schema.asdict())


### PR DESCRIPTION
Float fields default to f4 but can now be set to f2 (16-bit) or f8 (64-bit) by editing the dtype in a storage schema. Float sanitisation is now dtype-aware and emits values and the missing/fill sentinels directly in the target dtype, so ragged fields round-trip correctly across float widths. Missing and fill sentinels are defined per float dtype, and schema validation rejects unsupported float dtypes.

Closes #492